### PR TITLE
[FEAT] Embedding vector 및 Supabase 적재 코드 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 output/
 preprocessed/
+vectorized/
 venv/
 __pycache__/
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,13 @@
 output/
 preprocessed/
 vectorized/
+FILES/
 venv/
 __pycache__/
+supabase/
 *.log
 state.json
 inspect_site.py
 nav_output.txt
+.env
+.env.example

--- a/crawler.py
+++ b/crawler.py
@@ -8,8 +8,8 @@ https://ce.pknu.ac.kr/ce/1
   - 학사안내: 교육과정(전공별 포함), 모듈형 교육과정, 졸업요건
 
 저장 형식:
-  - output/json/<category>/<slug>.json
-  - output/html/<category>/<slug>.html
+  - FILES/output/json/<category>/<slug>.json
+  - FILES/output/html/<category>/<slug>.html
 
 증분 크롤링:
   - state.json 에 게시판별 마지막으로 수집한 게시글 번호를 저장
@@ -54,9 +54,9 @@ log = logging.getLogger(__name__)
 
 # ─── 경로 및 상수 ─────────────────────────────────────────────────────────────
 BASE_URL = "https://ce.pknu.ac.kr"
-OUTPUT_JSON = Path("output/json")
-OUTPUT_HTML = Path("output/html")
-OUTPUT_FILES = Path("output/files")
+OUTPUT_JSON = Path("FILES/output/json")
+OUTPUT_HTML = Path("FILES/output/html")
+OUTPUT_FILES = Path("FILES/output/files")
 STATE_FILE = Path("state.json")
 
 REQUEST_DELAY = 0.8      # 게시글 상세 요청 간 딜레이(초)

--- a/load_to_supabase.py
+++ b/load_to_supabase.py
@@ -1,0 +1,158 @@
+"""Load vectorized RAG chunks into Supabase PostgreSQL with pgvector.
+
+Expected input:
+    FILES/vectorized/index.jsonl
+
+Required environment:
+    DATABASE_URL or SUPABASE_DB_URL
+
+Alternative PG environment variables are also supported:
+    PGHOST, PGPORT, PGDATABASE, PGUSER, PGPASSWORD, PGSSLMODE
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Any, Iterable
+
+import psycopg
+from dotenv import load_dotenv
+from psycopg.types.json import Jsonb
+
+DEFAULT_INDEX_PATH = Path("FILES/vectorized/index.jsonl")
+EXPECTED_DIMENSIONS = 384
+
+
+def vector_literal(values: list[float]) -> str:
+    return "[" + ",".join(str(float(value)) for value in values) + "]"
+
+
+def connect() -> psycopg.Connection:
+    load_dotenv()
+    conninfo = os.getenv("DATABASE_URL") or os.getenv("SUPABASE_DB_URL")
+    if conninfo:
+        return psycopg.connect(conninfo, prepare_threshold=None)
+
+    required = ["PGHOST", "PGDATABASE", "PGUSER", "PGPASSWORD"]
+    missing = [name for name in required if not os.getenv(name)]
+    if missing:
+        raise RuntimeError(
+            "Missing database configuration. Set DATABASE_URL or SUPABASE_DB_URL, "
+            f"or set {', '.join(required)}."
+        )
+
+    return psycopg.connect(
+        host=os.environ["PGHOST"],
+        port=os.getenv("PGPORT", "5432"),
+        dbname=os.environ["PGDATABASE"],
+        user=os.environ["PGUSER"],
+        password=os.environ["PGPASSWORD"],
+        sslmode=os.getenv("PGSSLMODE", "require"),
+        prepare_threshold=None,
+    )
+
+
+def iter_records(index_path: Path) -> Iterable[dict[str, Any]]:
+    with index_path.open("r", encoding="utf-8-sig") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"Invalid JSON on line {line_number}: {exc}") from exc
+
+
+def prepare_row(record: dict[str, Any]) -> dict[str, Any]:
+    embedding = record.get("embedding")
+    if not isinstance(embedding, list):
+        raise ValueError(f"Record {record.get('id')} has no embedding list")
+    if len(embedding) != EXPECTED_DIMENSIONS:
+        raise ValueError(
+            f"Record {record.get('id')} has embedding dimension {len(embedding)}, "
+            f"expected {EXPECTED_DIMENSIONS}. Re-run: python vectorization.py --backend sentence-transformers"
+        )
+
+    content = record.get("text") or record.get("content") or ""
+    if not content:
+        raise ValueError(f"Record {record.get('id')} has empty text/content")
+
+    return {
+        "id": str(record["id"]),
+        "source_slug": str(record["source_slug"]),
+        "chunk_id": int(record["chunk_id"]),
+        "chunk_index": int(record["chunk_index"]),
+        "content": str(content),
+        "metadata": Jsonb(record.get("metadata") or {}),
+        "embedding": vector_literal(embedding),
+    }
+
+
+def flush_batch(conn: psycopg.Connection, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        return
+
+    sql = """
+        insert into public.rag_documents (
+            id, source_slug, chunk_id, chunk_index, content, metadata, embedding
+        )
+        values (
+            %(id)s,
+            %(source_slug)s,
+            %(chunk_id)s,
+            %(chunk_index)s,
+            %(content)s,
+            %(metadata)s,
+            %(embedding)s::extensions.vector(384)
+        )
+        on conflict (id) do update set
+            source_slug = excluded.source_slug,
+            chunk_id = excluded.chunk_id,
+            chunk_index = excluded.chunk_index,
+            content = excluded.content,
+            metadata = excluded.metadata,
+            embedding = excluded.embedding
+    """
+    with conn.cursor() as cur:
+        cur.executemany(sql, rows)
+
+
+def load(index_path: Path, batch_size: int) -> int:
+    if not index_path.exists():
+        raise FileNotFoundError(f"Index file not found: {index_path}")
+
+    total = 0
+    batch: list[dict[str, Any]] = []
+    with connect() as conn:
+        for record in iter_records(index_path):
+            batch.append(prepare_row(record))
+            if len(batch) >= batch_size:
+                flush_batch(conn, batch)
+                total += len(batch)
+                conn.commit()
+                print(f"upserted {total} rows")
+                batch.clear()
+
+        flush_batch(conn, batch)
+        total += len(batch)
+        conn.commit()
+
+    return total
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Load RAG chunks into Supabase PostgreSQL.")
+    parser.add_argument("--index", type=Path, default=DEFAULT_INDEX_PATH)
+    parser.add_argument("--batch-size", type=int, default=200)
+    args = parser.parse_args()
+
+    count = load(args.index, args.batch_size)
+    print(f"done: upserted {count} rows")
+
+
+if __name__ == "__main__":
+    main()

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -33,6 +33,10 @@ SUPPORTED_EXTS = {
 }
 DEFAULT_CHUNK_SIZE = 900
 DEFAULT_CHUNK_OVERLAP = 120
+DEFAULT_PDF_OCR_MODE = "auto"
+DEFAULT_OCR_LANGUAGE = "kor+eng"
+DEFAULT_OCR_DPI = 200
+MIN_USEFUL_PDF_TEXT_CHARS = 80
 
 
 def normalize_text(text: str) -> str:
@@ -41,6 +45,23 @@ def normalize_text(text: str) -> str:
     text = text.replace("\u00a0", " ")
     text = " ".join(text.split())
     return text.strip()
+
+
+def is_likely_broken_korean_text(text: str) -> bool:
+    normalized = normalize_text(text)
+    if len(normalized) < MIN_USEFUL_PDF_TEXT_CHARS:
+        return False
+    letters = re.findall(r"[A-Za-z\uac00-\ud7a3\u4e00-\u9fff]", normalized)
+    if not letters:
+        return False
+    hangul_count = len(re.findall(r"[\uac00-\ud7a3]", normalized))
+    cjk_count = len(re.findall(r"[\u4e00-\u9fff]", normalized))
+    replacement_count = normalized.count("\ufffd") + normalized.count("?")
+    return (
+        (cjk_count / len(letters) >= 0.15 and hangul_count / len(letters) <= 0.10)
+        or replacement_count / max(1, len(normalized)) >= 0.08
+        or normalized.count("??") >= 8
+    )
 
 
 def rel_project_path(path: Path, root: Path) -> str:
@@ -94,7 +115,7 @@ def load_attachment_index(output_json_root: Path, project_root: Path) -> dict[st
     return index
 
 
-def extract_pdf_blocks(path: Path) -> list[dict]:
+def extract_pdf_text_blocks(path: Path) -> list[dict]:
     try:
         import fitz  # type: ignore
     except Exception as exc:
@@ -208,6 +229,84 @@ def extract_pdf_blocks(path: Path) -> list[dict]:
     return blocks
 
 
+def extract_pdf_ocr_blocks(
+    path: Path,
+    ocr_language: str = DEFAULT_OCR_LANGUAGE,
+    ocr_dpi: int = DEFAULT_OCR_DPI,
+) -> list[dict]:
+    try:
+        import fitz  # type: ignore
+    except Exception as exc:
+        raise RuntimeError(f"PDF parser import failed (PyMuPDF/fitz required): {exc}") from exc
+
+    tesseract = shutil.which("tesseract")
+    if not tesseract:
+        log.warning("[OCR-SKIP] tesseract command not found: %s", path)
+        return []
+
+    blocks: list[dict] = []
+    doc = fitz.open(str(path))
+    temp_dir = Path(tempfile.mkdtemp(prefix="campus_rag_ocr_"))
+    try:
+        zoom = max(72, ocr_dpi) / 72
+        matrix = fitz.Matrix(zoom, zoom)
+        for page_num, page in enumerate(doc, start=1):
+            image_path = temp_dir / f"page-{page_num:04d}.png"
+            page.get_pixmap(matrix=matrix, alpha=False).save(str(image_path))
+            proc = subprocess.run(
+                [tesseract, str(image_path), "stdout", "-l", ocr_language, "--psm", "6"],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="ignore",
+                check=False,
+            )
+            if proc.returncode != 0:
+                err = normalize_text(proc.stderr) or "unknown error"
+                log.warning("[OCR-FAIL] %s page %d (%s)", path, page_num, err)
+                continue
+            text = normalize_text(proc.stdout)
+            if text:
+                blocks.append(
+                    {
+                        "type": "ocr_paragraph",
+                        "style": "Tesseract",
+                        "page": page_num,
+                        "text": text,
+                    }
+                )
+    finally:
+        doc.close()
+        shutil.rmtree(temp_dir, ignore_errors=True)
+    return blocks
+
+
+def extract_pdf_blocks(
+    path: Path,
+    ocr_mode: str = DEFAULT_PDF_OCR_MODE,
+    ocr_language: str = DEFAULT_OCR_LANGUAGE,
+    ocr_dpi: int = DEFAULT_OCR_DPI,
+) -> list[dict]:
+    blocks = extract_pdf_text_blocks(path)
+    text = "\n".join(normalize_text(b.get("text", "")) for b in blocks)
+    needs_ocr = (
+        ocr_mode == "always"
+        or (
+            ocr_mode == "auto"
+            and (
+                len(normalize_text(text)) < MIN_USEFUL_PDF_TEXT_CHARS
+                or is_likely_broken_korean_text(text)
+            )
+        )
+    )
+    if not needs_ocr:
+        return blocks
+    reason = "empty/short text" if len(normalize_text(text)) < MIN_USEFUL_PDF_TEXT_CHARS else "broken text"
+    log.info("[OCR] %s (%s)", path, reason)
+    ocr_blocks = extract_pdf_ocr_blocks(path, ocr_language=ocr_language, ocr_dpi=ocr_dpi)
+    return ocr_blocks or blocks
+
+
 def extract_docx_like_blocks(path: Path) -> list[dict]:
     suffix = path.suffix.lower()
     work_path = path
@@ -298,6 +397,164 @@ def extract_txt_blocks(path: Path) -> list[dict]:
     return blocks
 
 
+def extract_html_blocks(path: Path) -> list[dict]:
+    try:
+        from bs4 import BeautifulSoup
+        from bs4.element import Tag
+    except Exception as exc:
+        raise RuntimeError(f"HTML parser import failed (beautifulsoup4 required): {exc}") from exc
+
+    html = path.read_text(encoding="utf-8", errors="ignore")
+    soup = BeautifulSoup(html, "html.parser")
+
+    for tag in soup(["script", "style", "noscript", "svg", "canvas", "iframe", "form"]):
+        tag.decompose()
+
+    def attr_text(tag: Tag) -> str:
+        attrs: list[str] = []
+        tag_id = tag.get("id")
+        if tag_id:
+            attrs.append(str(tag_id))
+        classes = tag.get("class") or []
+        attrs.extend(str(cls) for cls in classes)
+        return " ".join(attrs).lower()
+
+    def is_noise(tag: Tag) -> bool:
+        if tag.name in {"nav", "header", "footer", "aside"}:
+            return True
+        attrs = attr_text(tag)
+        noise_keywords = (
+            "nav",
+            "gnb",
+            "lnb",
+            "snb",
+            "menu",
+            "header",
+            "footer",
+            "breadcrumb",
+            "quick",
+            "search",
+            "banner",
+            "popup",
+            "comment",
+            "reply",
+            "pagination",
+            "print",
+            "share",
+            "zoom",
+            "btn",
+            "button",
+        )
+        return any(keyword in attrs for keyword in noise_keywords)
+
+    def text_without_tables(tag: Tag) -> str:
+        parts: list[str] = []
+        for child in tag.children:
+            if isinstance(child, str):
+                parts.append(child)
+                continue
+            if not isinstance(child, Tag):
+                continue
+            if child.name == "table":
+                continue
+            parts.append(text_without_tables(child))
+        return normalize_text(" ".join(parts))
+
+    def element_score(tag: Tag) -> int:
+        text = normalize_text(tag.get_text(" ", strip=True))
+        if len(text) < 80:
+            return -1
+        attrs = attr_text(tag)
+        score = len(text)
+        if any(keyword in attrs for keyword in ("content", "cont", "board", "view", "article", "body", "main", "read", "detail")):
+            score += 400
+        if any(keyword in attrs for keyword in ("nav", "menu", "header", "footer", "banner", "search", "quick")):
+            score -= 300
+        return score
+
+    body = soup.body or soup
+    candidates: list[Tag] = [body]
+    for tag in body.find_all(["main", "article", "section", "div", "td"]):
+        if is_noise(tag):
+            continue
+        candidates.append(tag)
+
+    root = max(candidates, key=element_score)
+
+    blocks: list[dict] = []
+    seen_texts: set[str] = set()
+    ignored_texts = {
+        "확대",
+        "축소",
+        "프린트",
+        "인쇄",
+        "공유",
+        "목록",
+        "다음글",
+        "이전글",
+    }
+
+    def append_block(block_type: str, style: str, text: str) -> None:
+        text = normalize_text(text)
+        if not text or text in seen_texts or text in ignored_texts:
+            return
+        seen_texts.add(text)
+        blocks.append({"type": block_type, "style": style, "text": text})
+
+    title = normalize_text((soup.title.string if soup.title and soup.title.string else ""))
+    if title:
+        append_block("heading", "HTMLTitle", title)
+
+    def table_to_text(table_tag: Tag) -> str:
+        rows: list[str] = []
+        for tr in table_tag.find_all("tr"):
+            cells: list[str] = []
+            for cell in tr.find_all(["th", "td"], recursive=False):
+                cell_text = text_without_tables(cell)
+                if cell_text:
+                    cells.append(cell_text)
+            if cells:
+                rows.append(" | ".join(cells))
+        return "\n".join(rows)
+
+    def walk(tag: Tag) -> None:
+        if is_noise(tag):
+            return
+
+        if tag.name == "table":
+            table_text = table_to_text(tag)
+            if table_text:
+                append_block("table", "HTMLTable", table_text)
+            return
+
+        if tag.name in {"h1", "h2", "h3", "h4", "h5", "h6"}:
+            append_block("heading", tag.name.upper(), text_without_tables(tag))
+        elif tag.name == "p":
+            append_block("paragraph", "HTMLParagraph", text_without_tables(tag))
+        elif tag.name == "li":
+            append_block("list_item", "HTMLListItem", text_without_tables(tag))
+        elif tag.name in {"blockquote", "pre"}:
+            append_block("paragraph", tag.name.upper(), text_without_tables(tag))
+
+        for child in tag.children:
+            if isinstance(child, Tag):
+                walk(child)
+
+    walk(root)
+
+    if blocks:
+        return blocks
+
+    fallback_lines = [
+        normalize_text(line)
+        for line in root.get_text("\n", strip=True).splitlines()
+        if normalize_text(line)
+    ]
+    for line in fallback_lines:
+        append_block("paragraph", "HTMLText", line)
+    return blocks
+
+
 def extract_hwpx_blocks(path: Path) -> list[dict]:
     blocks: list[dict] = []
     with zipfile.ZipFile(path) as zf:
@@ -327,6 +584,16 @@ def extract_hwpx_blocks(path: Path) -> list[dict]:
 
 
 def extract_hwp_blocks(path: Path) -> list[dict]:
+    def format_hwp_runtime_error(stderr: str) -> str:
+        err = stderr.strip() or "unknown error"
+        if "No module named 'six'" in err or 'No module named "six"' in err:
+            return (
+                "pyhwp runtime dependency 'six' is missing in the interpreter used by "
+                "hwp5txt/hwp5html. Install it in the same environment, for example: "
+                f'"{sys.executable}" -m pip install six'
+            )
+        return err
+
     def resolve_hwp_command(command_name: str) -> str | None:
         resolved = shutil.which(command_name)
         if resolved:
@@ -368,6 +635,7 @@ def extract_hwp_blocks(path: Path) -> list[dict]:
                 check=False,
             )
             if proc.returncode != 0:
+                log.debug("hwp5html failed for %s: %s", path, format_hwp_runtime_error(proc.stderr))
                 return []
 
             if not html_file.exists():
@@ -480,8 +748,7 @@ def extract_hwp_blocks(path: Path) -> list[dict]:
         check=False,
     )
     if proc.returncode != 0:
-        err = proc.stderr.strip() or "unknown error"
-        raise RuntimeError(f"hwp5txt failed: {err}")
+        raise RuntimeError(f"hwp5txt failed: {format_hwp_runtime_error(proc.stderr)}")
 
     lines = [normalize_text(line) for line in proc.stdout.splitlines()]
     lines = [line for line in lines if line]
@@ -499,21 +766,58 @@ def extract_hwp_blocks(path: Path) -> list[dict]:
     return blocks
 
 
-def extract_blocks(path: Path) -> list[dict]:
+def extract_blocks(
+    path: Path,
+    pdf_ocr_mode: str = DEFAULT_PDF_OCR_MODE,
+    ocr_language: str = DEFAULT_OCR_LANGUAGE,
+    ocr_dpi: int = DEFAULT_OCR_DPI,
+) -> list[dict]:
     ext = path.suffix.lower()
     if ext == ".pdf":
-        return extract_pdf_blocks(path)
+        return extract_pdf_blocks(
+            path,
+            ocr_mode=pdf_ocr_mode,
+            ocr_language=ocr_language,
+            ocr_dpi=ocr_dpi,
+        )
     if ext in {".docx", ".doc"}:
         return extract_docx_like_blocks(path)
+    if ext in {".html", ".htm"}:
+        return extract_html_blocks(path)
     if ext == ".csv":
         return extract_csv_blocks(path)
     if ext == ".txt":
         return extract_txt_blocks(path)
     if ext == ".hwpx":
-        return extract_hwpx_blocks(path)
+        return extract_hwpx_blocks(path)    
     if ext == ".hwp":
         return extract_hwp_blocks(path)
     raise ValueError(f"unsupported extension: {ext}")
+
+
+def build_metadata_fallback_blocks(
+    input_file: Path,
+    rel: str,
+    rel_in_input: str,
+    provenance: dict,
+) -> list[dict]:
+    fields = [
+        ("문서 파일명", input_file.name),
+        ("문서 경로", rel_in_input),
+        ("문서 제목", provenance.get("doc_title", "")),
+        ("게시글 URL", provenance.get("doc_url", "")),
+        ("카테고리", provenance.get("category", "")),
+        ("하위 카테고리", provenance.get("subcategory", "")),
+        ("첨부파일명", provenance.get("attachment_name", "")),
+        ("첨부파일 URL", provenance.get("attachment_url", "")),
+        ("출처 페이지", provenance.get("source_page_url", "")),
+        ("출처 사이트", provenance.get("source_site", "")),
+        ("저장 경로", rel),
+    ]
+    lines = [f"{label}: {value}" for label, value in fields if normalize_text(str(value))]
+    if not lines:
+        return []
+    return [{"type": "metadata_fallback", "style": "Metadata", "text": "\n".join(lines)}]
 
 
 def chunk_blocks(
@@ -577,21 +881,37 @@ def save_preprocessed_file(
     attachment_index: dict[str, dict],
     chunk_size: int,
     chunk_overlap: int,
+    pdf_ocr_mode: str,
+    ocr_language: str,
+    ocr_dpi: int,
 ) -> tuple[bool, str]:
     rel = rel_project_path(input_file, project_root)
     ext = input_file.suffix.lower()
     if ext not in SUPPORTED_EXTS:
         return False, "unsupported"
 
-    blocks = extract_blocks(input_file)
+    rel_in_input = rel_project_path(input_file, input_root)
+    provenance = attachment_index.get(rel, {})
+    blocks = extract_blocks(
+        input_file,
+        pdf_ocr_mode=pdf_ocr_mode,
+        ocr_language=ocr_language,
+        ocr_dpi=ocr_dpi,
+    )
     blocks = [b for b in blocks if normalize_text(b.get("text", ""))]
     chunks = chunk_blocks(blocks, chunk_size=chunk_size, overlap=chunk_overlap)
+    used_metadata_fallback = False
+    if not chunks:
+        fallback_blocks = build_metadata_fallback_blocks(input_file, rel, rel_in_input, provenance)
+        fallback_chunks = chunk_blocks(fallback_blocks, chunk_size=chunk_size, overlap=0)
+        if fallback_chunks:
+            blocks = fallback_blocks
+            chunks = fallback_chunks
+            used_metadata_fallback = True
 
     out_path = ensure_output_path(input_file, input_root, output_root)
     out_path.parent.mkdir(parents=True, exist_ok=True)
 
-    rel_in_input = rel_project_path(input_file, input_root)
-    provenance = attachment_index.get(rel, {})
     result = {
         "slug": make_slug(rel),
         "source_file": input_file.name,
@@ -602,6 +922,7 @@ def save_preprocessed_file(
         "num_blocks": len(blocks),
         "total_chars": sum(len(b["text"]) for b in blocks),
         "num_chunks": len(chunks),
+        "used_metadata_fallback": used_metadata_fallback,
         "provenance": provenance,
         "blocks": blocks,
         "chunks": chunks,
@@ -629,6 +950,9 @@ def run_batch(
     dry_run: bool,
     chunk_size: int,
     chunk_overlap: int,
+    pdf_ocr_mode: str,
+    ocr_language: str,
+    ocr_dpi: int,
 ) -> None:
     attachment_index = load_attachment_index(output_json_root, project_root)
     files = iter_target_files(input_root)
@@ -655,6 +979,9 @@ def run_batch(
                 attachment_index=attachment_index,
                 chunk_size=chunk_size,
                 chunk_overlap=chunk_overlap,
+                pdf_ocr_mode=pdf_ocr_mode,
+                ocr_language=ocr_language,
+                ocr_dpi=ocr_dpi,
             )
             if saved:
                 ok += 1
@@ -674,24 +1001,24 @@ def run_batch(
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="output/files 첨부파일을 RAG용 전처리 JSON으로 변환"
+        description="FILES/output/files 첨부파일을 RAG용 전처리 JSON으로 변환"
     )
     parser.add_argument(
         "--input-root",
         type=Path,
-        default=Path("output/files"),
+        default=Path("FILES/output/files"),
         help="원본 첨부파일 루트 경로",
     )
     parser.add_argument(
         "--output-root",
         type=Path,
-        default=Path("preprocessed"),
+        default=Path("FILES/preprocessed"),
         help="전처리 JSON 출력 루트 경로",
     )
     parser.add_argument(
         "--output-json-root",
         type=Path,
-        default=Path("output/json"),
+        default=Path("FILES/output/json"),
         help="크롤링 본문 JSON 루트 (첨부 provenance 조인용)",
     )
     parser.add_argument(
@@ -711,6 +1038,23 @@ def main() -> None:
         default=DEFAULT_CHUNK_OVERLAP,
         help="연속 청크 간 문자 오버랩 길이",
     )
+    parser.add_argument(
+        "--pdf-ocr",
+        choices=["auto", "never", "always"],
+        default=DEFAULT_PDF_OCR_MODE,
+        help="PDF OCR fallback 사용 방식",
+    )
+    parser.add_argument(
+        "--ocr-language",
+        default=DEFAULT_OCR_LANGUAGE,
+        help="Tesseract OCR 언어 설정",
+    )
+    parser.add_argument(
+        "--ocr-dpi",
+        type=int,
+        default=DEFAULT_OCR_DPI,
+        help="PDF 페이지를 OCR 이미지로 렌더링할 DPI",
+    )
     args = parser.parse_args()
 
     logging.basicConfig(
@@ -726,6 +1070,9 @@ def main() -> None:
         dry_run=args.dry_run,
         chunk_size=args.chunk_size,
         chunk_overlap=args.chunk_overlap,
+        pdf_ocr_mode=args.pdf_ocr,
+        ocr_language=args.ocr_language,
+        ocr_dpi=args.ocr_dpi,
     )
 
 

--- a/query_supabase.py
+++ b/query_supabase.py
@@ -1,0 +1,114 @@
+"""Query Supabase PostgreSQL RAG chunks with the same embedding model."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from typing import Any
+
+import psycopg
+from dotenv import load_dotenv
+from psycopg.rows import dict_row
+
+DEFAULT_MODEL = "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
+EXPECTED_DIMENSIONS = 384
+
+
+def connect() -> psycopg.Connection:
+    load_dotenv()
+    conninfo = os.getenv("DATABASE_URL") or os.getenv("SUPABASE_DB_URL")
+    if conninfo:
+        return psycopg.connect(conninfo, row_factory=dict_row, prepare_threshold=None)
+
+    required = ["PGHOST", "PGDATABASE", "PGUSER", "PGPASSWORD"]
+    missing = [name for name in required if not os.getenv(name)]
+    if missing:
+        raise RuntimeError(
+            "Missing database configuration. Set DATABASE_URL or SUPABASE_DB_URL, "
+            f"or set {', '.join(required)}."
+        )
+
+    return psycopg.connect(
+        host=os.environ["PGHOST"],
+        port=os.getenv("PGPORT", "5432"),
+        dbname=os.environ["PGDATABASE"],
+        user=os.environ["PGUSER"],
+        password=os.environ["PGPASSWORD"],
+        sslmode=os.getenv("PGSSLMODE", "require"),
+        row_factory=dict_row,
+        prepare_threshold=None,
+    )
+
+
+def embed_query(question: str, model_name: str) -> list[float]:
+    from sentence_transformers import SentenceTransformer
+
+    model = SentenceTransformer(model_name)
+    dimensions = int(model.get_sentence_embedding_dimension() or 0)
+    if dimensions != EXPECTED_DIMENSIONS:
+        raise ValueError(
+            f"Model {model_name} produces {dimensions} dimensions, expected {EXPECTED_DIMENSIONS}."
+        )
+
+    vector = model.encode([question], normalize_embeddings=True, show_progress_bar=False)[0]
+    return [round(float(value), 8) for value in vector]
+
+
+def vector_literal(values: list[float]) -> str:
+    return "[" + ",".join(str(float(value)) for value in values) + "]"
+
+
+def search(question: str, model_name: str, top_k: int, min_similarity: float) -> list[dict[str, Any]]:
+    embedding = vector_literal(embed_query(question, model_name))
+    sql = """
+        select *
+        from public.match_rag_documents(
+            %(embedding)s::extensions.vector(384),
+            %(top_k)s,
+            %(min_similarity)s,
+            '{}'::jsonb
+        )
+    """
+    with connect() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                sql,
+                {
+                    "embedding": embedding,
+                    "top_k": top_k,
+                    "min_similarity": min_similarity,
+                },
+            )
+            return list(cur.fetchall())
+
+
+def print_results(rows: list[dict[str, Any]]) -> None:
+    for rank, row in enumerate(rows, start=1):
+        metadata = row.get("metadata") or {}
+        title = metadata.get("doc_title") or metadata.get("source_file") or row["source_slug"]
+        url = metadata.get("doc_url") or metadata.get("source_page_url") or metadata.get("attachment_url") or ""
+        content = " ".join(str(row["content"]).split())
+        snippet = content[:300] + ("..." if len(content) > 300 else "")
+
+        print(f"\n#{rank} similarity={row['similarity']:.4f}")
+        print(f"title: {title}")
+        if url:
+            print(f"url: {url}")
+        print(f"source_slug: {row['source_slug']} chunk_index: {row['chunk_index']}")
+        print(f"snippet: {snippet}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Semantic search against Supabase RAG chunks.")
+    parser.add_argument("question")
+    parser.add_argument("--model-name", default=DEFAULT_MODEL)
+    parser.add_argument("--top-k", type=int, default=5)
+    parser.add_argument("--min-similarity", type=float, default=0.0)
+    args = parser.parse_args()
+
+    rows = search(args.question, args.model_name, args.top_k, args.min_similarity)
+    print_results(rows)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,10 @@ charset-normalizer==3.4.6
 idna==3.11
 lxml==6.0.2
 PyMuPDF==1.26.5
+psycopg[binary]
+psycopg2==2.9.12
 python-docx==1.2.0
+python-dotenv
 pywin32==311; platform_system == "Windows"
 pyhwp==0.1b15
 requests==2.33.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ pywin32==311; platform_system == "Windows"
 pyhwp==0.1b15
 requests==2.33.0
 schedule==1.2.2
+sentence-transformers
 soupsieve==2.8.3
 typing_extensions==4.15.0
 urllib3==2.6.3

--- a/vectorization.py
+++ b/vectorization.py
@@ -1,13 +1,13 @@
 """preprocessed JSON을 RAG 검색용 벡터 파일로 변환하는 스크립트.
 
 동작 요약:
-1. /preprocessed 아래의 전처리 JSON 파일을 모두 찾는다.
+1. /FILES/preprocessed 아래의 전처리 JSON 파일을 모두 찾는다.
 2. 각 JSON의 chunks 배열에서 검색 단위 텍스트와 출처 메타데이터를 꺼낸다.
 3. 기본값으로 추가 패키지 없이 동작하는 해시 기반 임베딩을 생성한다.
    sentence-transformers가 설치되어 있으면 옵션으로 의미 기반 임베딩도 사용할 수 있다.
-4. 파일별 벡터 결과는 /vectorized에 같은 폴더 구조로 저장한다.
-5. 전체 청크를 한 번에 불러오기 쉬운 /vectorized/index.jsonl과
-   실행 요약인 /vectorized/manifest.json을 함께 만든다.
+4. 파일별 벡터 결과는 /FILES/vectorized에 같은 폴더 구조로 저장한다.
+5. 전체 청크를 한 번에 불러오기 쉬운 /FILES/vectorized/index.jsonl과
+   실행 요약인 /FILES/vectorized/manifest.json을 함께 만든다.
 
 기본 실행:
     python vectorization.py
@@ -35,8 +35,8 @@ from typing import Iterable, Protocol
 log = logging.getLogger(__name__)
 
 # CLI 기본값: 입력/출력 경로와 임베딩 방식 설정.
-DEFAULT_INPUT_ROOT = Path("preprocessed")
-DEFAULT_OUTPUT_ROOT = Path("vectorized")
+DEFAULT_INPUT_ROOT = Path("FILES/preprocessed")
+DEFAULT_OUTPUT_ROOT = Path("FILES/vectorized")
 DEFAULT_BACKEND = "hash"
 DEFAULT_DIMENSIONS = 768
 DEFAULT_BATCH_SIZE = 32
@@ -280,7 +280,7 @@ def vectorize_file(
 ) -> tuple[int, Path]:
     """전처리 JSON 파일 하나를 벡터화하고 파일별 결과와 JSONL 인덱스를 저장한다."""
 
-    doc = json.loads(input_file.read_text(encoding="utf-8"))
+    doc = json.loads(input_file.read_text(encoding="utf-8-sig"))
     records = extract_chunk_records(doc, input_file, project_root)
     if not records:
         raise NoChunksError("no chunks found")
@@ -454,7 +454,7 @@ def main() -> None:
 
     # 현재 작업 디렉터리를 프로젝트 루트로 사용한다.
     project_root = Path.cwd()
-    embedder = make_embedder(args)
+    embedder = HashEmbedder(1) if args.dry_run else make_embedder(args)
     run_batch(
         input_root=args.input_root,
         output_root=args.output_root,

--- a/vectorization.py
+++ b/vectorization.py
@@ -1,0 +1,469 @@
+"""preprocessed JSON을 RAG 검색용 벡터 파일로 변환하는 스크립트.
+
+동작 요약:
+1. /preprocessed 아래의 전처리 JSON 파일을 모두 찾는다.
+2. 각 JSON의 chunks 배열에서 검색 단위 텍스트와 출처 메타데이터를 꺼낸다.
+3. 기본값으로 추가 패키지 없이 동작하는 해시 기반 임베딩을 생성한다.
+   sentence-transformers가 설치되어 있으면 옵션으로 의미 기반 임베딩도 사용할 수 있다.
+4. 파일별 벡터 결과는 /vectorized에 같은 폴더 구조로 저장한다.
+5. 전체 청크를 한 번에 불러오기 쉬운 /vectorized/index.jsonl과
+   실행 요약인 /vectorized/manifest.json을 함께 만든다.
+
+기본 실행:
+    python vectorization.py
+
+실행 전 파일 확인:
+    python vectorization.py --dry-run
+
+sentence-transformers 사용:
+    python vectorization.py --backend sentence-transformers
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import math
+import re
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, Protocol
+
+log = logging.getLogger(__name__)
+
+# CLI 기본값: 입력/출력 경로와 임베딩 방식 설정.
+DEFAULT_INPUT_ROOT = Path("preprocessed")
+DEFAULT_OUTPUT_ROOT = Path("vectorized")
+DEFAULT_BACKEND = "hash"
+DEFAULT_DIMENSIONS = 768
+DEFAULT_BATCH_SIZE = 32
+DEFAULT_SENTENCE_MODEL = "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
+
+
+class NoChunksError(ValueError):
+    """전처리 JSON에 사용할 수 있는 청크가 없을 때 발생하는 예외."""
+
+    pass
+
+
+class Embedder(Protocol):
+    """해시 임베딩과 모델 임베딩이 공통으로 따라야 하는 인터페이스."""
+
+    name: str
+    dimensions: int
+
+    def embed_texts(self, texts: list[str]) -> list[list[float]]:
+        ...
+
+
+def normalize_text(text: str) -> str:
+    """임베딩 또는 저장 전에 텍스트의 공백을 일정하게 정리한다."""
+
+    if not text:
+        return ""
+    return " ".join(text.replace("\u00a0", " ").split()).strip()
+
+
+def rel_project_path(path: Path, root: Path) -> str:
+    """가능하면 프로젝트 기준 상대 경로를 반환하고, 불가능하면 절대 경로를 반환한다."""
+
+    try:
+        return path.resolve().relative_to(root.resolve()).as_posix()
+    except ValueError:
+        return path.resolve().as_posix()
+
+
+def stable_id(*parts: object, length: int = 16) -> str:
+    """출처 정보와 청크 정보를 바탕으로 항상 같은 짧은 ID를 만든다."""
+
+    raw = "::".join(str(p) for p in parts)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:length]
+
+
+def iter_json_files(input_root: Path) -> list[Path]:
+    """입력 폴더 아래의 모든 전처리 JSON 파일을 찾는다."""
+
+    if not input_root.exists():
+        return []
+    return sorted(p for p in input_root.rglob("*.json") if p.is_file())
+
+
+def output_path_for(input_file: Path, input_root: Path, output_root: Path) -> Path:
+    """전처리 파일의 하위 경로 구조를 vectorized 폴더 아래에 그대로 대응시킨다."""
+
+    rel = input_file.resolve().relative_to(input_root.resolve())
+    return output_root / rel
+
+
+def batched(items: list[str], batch_size: int) -> Iterable[list[str]]:
+    """임베딩 호출을 효율적으로 하기 위해 항목을 고정 크기 묶음으로 나눈다."""
+
+    for start in range(0, len(items), batch_size):
+        yield items[start : start + batch_size]
+
+
+def token_features(text: str) -> Counter[str]:
+    """HashEmbedder가 사용할 토큰과 문자 n-gram 특징을 추출한다."""
+
+    text = normalize_text(text).lower()
+    features: Counter[str] = Counter()
+
+    # 숫자, 영문 단어, 한글 음절을 토큰으로 인식한다.
+    for token in re.findall(r"[0-9a-zA-Z\uac00-\ud7a3]+", text):
+        features[f"tok:{token}"] += 1
+        if len(token) >= 4:
+            # 긴 토큰은 3글자 조각도 추가해 부분 일치 성능을 보완한다.
+            for i in range(len(token) - 2):
+                features[f"tri:{token[i:i + 3]}"] += 1
+
+    compact = re.sub(r"\s+", " ", text)
+    for i in range(max(0, len(compact) - 2)):
+        gram = compact[i : i + 3]
+        if gram.strip():
+            features[f"chr:{gram}"] += 1
+
+    return features
+
+
+class HashEmbedder:
+    """추가 패키지 없이 동작하는 결정적 해시 기반 임베딩.
+
+    의미를 학습한 모델은 아니며, 텍스트 특징을 고정 차원 벡터에 해시해서 넣는 방식이다.
+    sentence-transformers 같은 모델을 설치하기 전에도 전체 파이프라인을 실행할 수 있도록
+    기본 검색용 벡터를 제공한다.
+    """
+
+    def __init__(self, dimensions: int) -> None:
+        """고정 벡터 차원 수를 설정한다."""
+
+        if dimensions <= 0:
+            raise ValueError("dimensions must be positive")
+        self.name = "hash"
+        self.dimensions = dimensions
+
+    def embed_texts(self, texts: list[str]) -> list[list[float]]:
+        """여러 텍스트를 해시 기반 방식으로 벡터화한다."""
+
+        return [self._embed_one(text) for text in texts]
+
+    def _embed_one(self, text: str) -> list[float]:
+        """하나의 텍스트 청크를 L2 정규화된 벡터로 변환한다."""
+
+        vector = [0.0] * self.dimensions
+        features = token_features(text)
+        if not features:
+            return vector
+
+        for feature, count in features.items():
+            # feature hashing으로 임의의 텍스트 특징을 고정 길이 벡터 인덱스에 배치한다.
+            digest = hashlib.blake2b(feature.encode("utf-8"), digest_size=8).digest()
+            hashed = int.from_bytes(digest, byteorder="big", signed=False)
+            index = hashed % self.dimensions
+            sign = -1.0 if ((hashed >> 8) & 1) else 1.0
+            vector[index] += sign * (1.0 + math.log(count))
+
+        # 정규화하면 코사인 유사도를 단순 내적으로 계산할 수 있다.
+        norm = math.sqrt(sum(value * value for value in vector))
+        if norm:
+            vector = [round(value / norm, 8) for value in vector]
+        return vector
+
+
+class SentenceTransformerEmbedder:
+    """sentence-transformers를 사용하는 선택형 의미 기반 임베딩 백엔드."""
+
+    def __init__(self, model_name: str) -> None:
+        """지정한 SentenceTransformer 모델을 로드한다."""
+
+        try:
+            from sentence_transformers import SentenceTransformer  # type: ignore
+        except Exception as exc:
+            raise RuntimeError(
+                "sentence-transformers is not installed. "
+                "Install it or run with --backend hash."
+            ) from exc
+
+        self.model_name = model_name
+        self.model = SentenceTransformer(model_name)
+        self.name = f"sentence-transformers:{model_name}"
+        dim = self.model.get_sentence_embedding_dimension()
+        self.dimensions = int(dim) if dim else 0
+
+    def embed_texts(self, texts: list[str]) -> list[list[float]]:
+        """텍스트 청크 묶음을 모델 기반 정규화 벡터로 변환한다."""
+
+        vectors = self.model.encode(
+            texts,
+            normalize_embeddings=True,
+            show_progress_bar=False,
+        )
+        return [[round(float(value), 8) for value in row] for row in vectors]
+
+
+def make_embedder(args: argparse.Namespace) -> Embedder:
+    """CLI 옵션에 따라 사용할 임베딩 백엔드를 생성한다."""
+
+    if args.backend == "hash":
+        return HashEmbedder(args.dimensions)
+    if args.backend == "sentence-transformers":
+        return SentenceTransformerEmbedder(args.model_name)
+    raise ValueError(f"unsupported backend: {args.backend}")
+
+
+def extract_chunk_records(doc: dict, input_file: Path, project_root: Path) -> list[dict]:
+    """전처리 청크를 아직 embedding이 없는 검색 record로 변환한다."""
+
+    chunks = doc.get("chunks") or []
+    if not isinstance(chunks, list):
+        return []
+
+    source_slug = doc.get("slug") or stable_id(rel_project_path(input_file, project_root))
+    provenance = doc.get("provenance") or {}
+    # RAG 답변에서 출처를 표시할 수 있도록 모든 청크에 provenance 메타데이터를 보존한다.
+    base_metadata = {
+        "source_slug": source_slug,
+        "source_file": doc.get("source_file", ""),
+        "source_path": doc.get("source_path", ""),
+        "source_relative_to_input": doc.get("source_relative_to_input", ""),
+        "source_ext": doc.get("source_ext", ""),
+        "preprocessed_path": rel_project_path(input_file, project_root),
+        "doc_title": provenance.get("doc_title", ""),
+        "doc_url": provenance.get("doc_url", ""),
+        "category": provenance.get("category", ""),
+        "subcategory": provenance.get("subcategory", ""),
+        "attachment_name": provenance.get("attachment_name", ""),
+        "attachment_url": provenance.get("attachment_url", ""),
+        "source_page_url": provenance.get("source_page_url", ""),
+        "source_site": provenance.get("source_site", ""),
+    }
+
+    records: list[dict] = []
+    for position, chunk in enumerate(chunks, start=1):
+        # 잘못된 형식이거나 비어 있는 청크는 전체 파일 실패로 처리하지 않고 건너뛴다.
+        if not isinstance(chunk, dict):
+            continue
+        text = normalize_text(chunk.get("text", ""))
+        if not text:
+            continue
+
+        chunk_id = chunk.get("chunk_id", position)
+        record_id = stable_id(source_slug, chunk_id, text[:128])
+        # 이 record 하나가 벡터 인덱스에서 검색되는 최소 단위가 된다.
+        records.append(
+            {
+                "id": record_id,
+                "source_slug": source_slug,
+                "chunk_id": chunk_id,
+                "chunk_index": position - 1,
+                "text": text,
+                "metadata": {
+                    **base_metadata,
+                    "num_chars": chunk.get("num_chars", len(text)),
+                    "num_lines": chunk.get("num_lines"),
+                },
+            }
+        )
+    return records
+
+
+def vectorize_file(
+    input_file: Path,
+    input_root: Path,
+    output_root: Path,
+    project_root: Path,
+    embedder: Embedder,
+    batch_size: int,
+    index_handle,
+) -> tuple[int, Path]:
+    """전처리 JSON 파일 하나를 벡터화하고 파일별 결과와 JSONL 인덱스를 저장한다."""
+
+    doc = json.loads(input_file.read_text(encoding="utf-8"))
+    records = extract_chunk_records(doc, input_file, project_root)
+    if not records:
+        raise NoChunksError("no chunks found")
+
+    texts = [record["text"] for record in records]
+    vectors: list[list[float]] = []
+    for batch in batched(texts, batch_size):
+        # 모델 기반 임베딩에서는 배치 처리가 성능에 중요하다.
+        vectors.extend(embedder.embed_texts(batch))
+
+    for record, vector in zip(records, vectors):
+        record["embedding"] = vector
+
+    # vectorized 폴더 아래에도 preprocessed와 같은 하위 경로 구조를 유지한다.
+    out_path = output_path_for(input_file, input_root, output_root)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    result = {
+        "source_preprocessed_path": rel_project_path(input_file, project_root),
+        "vectorized_at": datetime.now().isoformat(),
+        "embedding_backend": embedder.name,
+        "embedding_dimensions": embedder.dimensions,
+        "num_chunks": len(records),
+        "records": records,
+    }
+    out_path.write_text(json.dumps(result, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    # 평평한 JSONL 인덱스는 DB 삽입이나 벡터 스토어 적재에 편하다.
+    for record in records:
+        index_handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    return len(records), out_path
+
+
+def run_batch(
+    input_root: Path,
+    output_root: Path,
+    project_root: Path,
+    embedder: Embedder,
+    batch_size: int,
+    dry_run: bool,
+) -> None:
+    """입력 폴더 아래의 모든 전처리 JSON 파일을 벡터화한다."""
+
+    files = iter_json_files(input_root)
+    if not files:
+        log.info("No preprocessed JSON files found under %s", input_root)
+        return
+
+    log.info("Found %d preprocessed files", len(files))
+    if dry_run:
+        for path in files:
+            log.info("[DRY-RUN] %s", rel_project_path(path, project_root))
+        return
+
+    output_root.mkdir(parents=True, exist_ok=True)
+    index_path = output_root / "index.jsonl"
+    manifest_path = output_root / "manifest.json"
+
+    ok = 0
+    skipped = 0
+    failed = 0
+    total_chunks = 0
+    skipped_files: list[dict] = []
+    failures: list[dict] = []
+
+    with index_path.open("w", encoding="utf-8") as index_handle:
+        for file_path in files:
+            rel = rel_project_path(file_path, project_root)
+            try:
+                chunk_count, out_path = vectorize_file(
+                    input_file=file_path,
+                    input_root=input_root,
+                    output_root=output_root,
+                    project_root=project_root,
+                    embedder=embedder,
+                    batch_size=batch_size,
+                    index_handle=index_handle,
+                )
+                ok += 1
+                total_chunks += chunk_count
+                log.info("[OK] %s -> %s (%d chunks)", rel, out_path.as_posix(), chunk_count)
+            except NoChunksError as exc:
+                # 이미지 기반 PDF처럼 텍스트 추출 결과가 비어 있는 파일은 skip으로 기록한다.
+                skipped += 1
+                skipped_files.append({"path": rel, "reason": str(exc)})
+                log.info("[SKIP] %s (%s)", rel, exc)
+            except Exception as exc:
+                # 예상하지 못한 오류는 skip과 구분해 failed로 기록한다.
+                failed += 1
+                failures.append({"path": rel, "error": str(exc)})
+                log.warning("[FAIL] %s (%s)", rel, exc)
+
+    # manifest는 이번 벡터화 실행 결과를 추적하기 위한 요약 파일이다.
+    manifest = {
+        "vectorized_at": datetime.now().isoformat(),
+        "input_root": rel_project_path(input_root, project_root),
+        "output_root": rel_project_path(output_root, project_root),
+        "embedding_backend": embedder.name,
+        "embedding_dimensions": embedder.dimensions,
+        "num_files": len(files),
+        "num_files_vectorized": ok,
+        "num_files_skipped": skipped,
+        "num_files_failed": failed,
+        "num_chunks": total_chunks,
+        "index_path": rel_project_path(index_path, project_root),
+        "skipped_files": skipped_files,
+        "failures": failures,
+    }
+    manifest_path.write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    log.info("Done: files=%d, chunks=%d, skipped=%d, failed=%d", ok, total_chunks, skipped, failed)
+
+
+def main() -> None:
+    """CLI 인자를 파싱하고 전체 벡터화 작업을 시작한다."""
+
+    parser = argparse.ArgumentParser(
+        description="Vectorize preprocessed chunk JSON files for RAG retrieval."
+    )
+    parser.add_argument(
+        "--input-root",
+        type=Path,
+        default=DEFAULT_INPUT_ROOT,
+        help="Preprocessed JSON root directory.",
+    )
+    parser.add_argument(
+        "--output-root",
+        type=Path,
+        default=DEFAULT_OUTPUT_ROOT,
+        help="Vectorized output root directory.",
+    )
+    parser.add_argument(
+        "--backend",
+        choices=["hash", "sentence-transformers"],
+        default=DEFAULT_BACKEND,
+        help="Embedding backend. Use hash for a dependency-free baseline.",
+    )
+    parser.add_argument(
+        "--model-name",
+        default=DEFAULT_SENTENCE_MODEL,
+        help="SentenceTransformer model name when --backend sentence-transformers is used.",
+    )
+    parser.add_argument(
+        "--dimensions",
+        type=int,
+        default=DEFAULT_DIMENSIONS,
+        help="Hash embedding dimensions when --backend hash is used.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=DEFAULT_BATCH_SIZE,
+        help="Embedding batch size.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="List target files without writing vectorized outputs.",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
+
+    if args.batch_size <= 0:
+        raise ValueError("--batch-size must be positive")
+
+    # 현재 작업 디렉터리를 프로젝트 루트로 사용한다.
+    project_root = Path.cwd()
+    embedder = make_embedder(args)
+    run_batch(
+        input_root=args.input_root,
+        output_root=args.output_root,
+        project_root=project_root,
+        embedder=embedder,
+        batch_size=args.batch_size,
+        dry_run=args.dry_run,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

`vectorization.py`의 기본 입출력 경로를 `FILES/` 기준으로 정리하고, Supabase pgvector 적재에 사용할 수 있도록 sentence-transformers 기반 embedding 생성 흐름을 명확히 했습니다.

Supabase PostgreSQL + pgvector 기반 RAG chunk 저장 및 semantic search 테스트 흐름을 추가했습니다.
Supabase의 `rag_documents` 테이블에 upsert할 수 있고, 동일한 sentence-transformers 모델로 질문 embedding을 생성해 semantic search를 테스트할 수 있습니다.


## Changes

- sentence-transformers backend 지원
  - 기본 모델: `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`
  - embedding dimension: 384
  - `normalize_embeddings=True`로 cosine similarity 검색에 맞게 정규화

- vectorized output 생성
  - `vectorization.py`
  - 파일별 vectorized JSON 저장
  - 전체 chunk 검색/적재용 `FILES/vectorized/index.jsonl` 생성
  - 실행 요약용 `FILES/vectorized/manifest.json` 생성

- Supabase SQL migration 추가
  - `vector` extension 활성화
  - `rag_documents` 테이블 생성
  - `embedding extensions.vector(384)` 컬럼 구성
  - `metadata jsonb` 컬럼 추가
  - HNSW cosine index 생성
  - `match_rag_documents` RPC 함수 생성

- Supabase 적재 스크립트 추가
  - `load_to_supabase.py`
  - `FILES/vectorized/index.jsonl` 읽기
  - `id`, `source_slug`, `chunk_id`, `chunk_index`, `content`, `metadata`, `embedding` upsert
  - 384차원 embedding 검증

- 검색 테스트 스크립트 추가
  - `query_supabase.py`
  - `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`로 질문 embedding 생성
  - `match_rag_documents` 호출
  - top-k 결과, similarity, source metadata, snippet 출력