### PR TITLE
[FEAT] json 파일 전처리 기능 추가

### DIFF
--- a/load_to_supabase.py
+++ b/load_to_supabase.py
@@ -270,7 +270,8 @@ def flush_batch(conn: psycopg.Connection, rows: list[dict[str, dict[str, Any]]])
             %(embedding_dim)s,
             %(embedded_at)s
         )
-        on conflict (id) do update set
+        on conflict (source_id, chunk_index) do update set
+            id = excluded.id,
             source_id = excluded.source_id,
             chunk_id = excluded.chunk_id,
             chunk_index = excluded.chunk_index,

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -39,6 +39,7 @@ def configure_logging() -> None:
     )
 
 SUPPORTED_EXTS = {
+    ".json",
     ".pdf",
     ".docx",
     ".doc",
@@ -129,6 +130,28 @@ def load_attachment_index(output_json_root: Path, project_root: Path) -> dict[st
                 "content_type": a.get("content_type", ""),
             }
     return index
+
+
+def extract_crawled_json_provenance(path: Path) -> dict:
+    try:
+        doc = json.loads(path.read_text(encoding="utf-8-sig"))
+    except Exception:
+        return {}
+    if not isinstance(doc, dict):
+        return {}
+
+    return {
+        "doc_title": doc.get("title", ""),
+        "doc_url": doc.get("url", ""),
+        "category": doc.get("category", ""),
+        "subcategory": doc.get("subcategory", ""),
+        "doc_type": doc.get("type", ""),
+        "date": doc.get("date", ""),
+        "is_notice": doc.get("is_notice", False),
+        "source_page_url": doc.get("url", ""),
+        "source_site": doc.get("source_site", ""),
+        "crawled_at": doc.get("crawled_at", ""),
+    }
 
 
 def extract_pdf_text_blocks(path: Path) -> list[dict]:
@@ -410,6 +433,42 @@ def extract_txt_blocks(path: Path) -> list[dict]:
                 "text": line,
             }
         )
+    return blocks
+
+
+def extract_json_blocks(path: Path) -> list[dict]:
+    doc = json.loads(path.read_text(encoding="utf-8-sig"))
+    if not isinstance(doc, dict):
+        raise ValueError("JSON root must be an object")
+
+    blocks: list[dict] = []
+
+    def append(block_type: str, style: str, text: object) -> None:
+        value = normalize_text(str(text or ""))
+        if value:
+            blocks.append({"type": block_type, "style": style, "text": value})
+
+    append("title", "PostTitle", doc.get("title", ""))
+    append("metadata", "PostDate", doc.get("date", ""))
+    append("metadata", "PostCategory", doc.get("category", ""))
+    append("metadata", "PostSubcategory", doc.get("subcategory", ""))
+    append("body", "PostBody", doc.get("content") or doc.get("body") or "")
+
+    attachments = doc.get("attachments") or []
+    if isinstance(attachments, list):
+        attachment_lines: list[str] = []
+        for attachment in attachments:
+            if not isinstance(attachment, dict):
+                continue
+            name = normalize_text(str(attachment.get("name", "")))
+            url = normalize_text(str(attachment.get("url", "")))
+            saved_path = normalize_text(str(attachment.get("saved_path", "")))
+            parts = [part for part in (name, url, saved_path) if part]
+            if parts:
+                attachment_lines.append(" | ".join(parts))
+        if attachment_lines:
+            append("attachments", "PostAttachments", "\n".join(attachment_lines))
+
     return blocks
 
 
@@ -789,6 +848,8 @@ def extract_blocks(
     ocr_dpi: int = DEFAULT_OCR_DPI,
 ) -> list[dict]:
     ext = path.suffix.lower()
+    if ext == ".json":
+        return extract_json_blocks(path)
     if ext == ".pdf":
         return extract_pdf_blocks(
             path,
@@ -908,6 +969,8 @@ def save_preprocessed_file(
 
     rel_in_input = rel_project_path(input_file, input_root)
     provenance = attachment_index.get(rel, {})
+    if ext == ".json":
+        provenance = {**extract_crawled_json_provenance(input_file), **provenance}
     blocks = extract_blocks(
         input_file,
         pdf_ocr_mode=pdf_ocr_mode,
@@ -1017,13 +1080,13 @@ def run_batch(
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="FILES/output/files 첨부파일을 RAG용 전처리 JSON으로 변환"
+        description="FILES/output의 게시글 JSON과 첨부 원문파일을 RAG용 전처리 JSON으로 변환"
     )
     parser.add_argument(
         "--input-root",
         type=Path,
-        default=Path("FILES/output/files"),
-        help="원본 첨부파일 루트 경로",
+        default=Path("FILES/output"),
+        help="원본 크롤링 결과 루트 경로",
     )
     parser.add_argument(
         "--output-root",

--- a/vectorization.py
+++ b/vectorization.py
@@ -251,6 +251,10 @@ def extract_chunk_records(doc: dict, input_file: Path, project_root: Path) -> li
         "doc_url": provenance.get("doc_url", ""),
         "category": provenance.get("category", ""),
         "subcategory": provenance.get("subcategory", ""),
+        "doc_type": provenance.get("doc_type", ""),
+        "date": provenance.get("date", ""),
+        "is_notice": provenance.get("is_notice", False),
+        "crawled_at": provenance.get("crawled_at", ""),
         "attachment_name": provenance.get("attachment_name", ""),
         "attachment_url": provenance.get("attachment_url", ""),
         "source_page_url": provenance.get("source_page_url", ""),
@@ -267,14 +271,15 @@ def extract_chunk_records(doc: dict, input_file: Path, project_root: Path) -> li
             continue
 
         chunk_id = chunk.get("chunk_id", position)
-        record_id = stable_id(source_slug, chunk_id, text[:128])
+        chunk_index = position - 1
+        record_id = stable_id(source_slug, chunk_index)
         # 이 record 하나가 벡터 인덱스에서 검색되는 최소 단위가 된다.
         records.append(
             {
                 "id": record_id,
                 "source_slug": source_slug,
                 "chunk_id": chunk_id,
-                "chunk_index": position - 1,
+                "chunk_index": chunk_index,
                 "text": text,
                 "metadata": {
                     **base_metadata,


### PR DESCRIPTION
## 개요

- 기존 첨부 파일만 전처리 되던 코드에서 json 파일과 원문 파일도 전처리 되도록 코드를 수정하였습니다.

## 설명

- `preprocessing.py`와 `vectorization.py`에 json 파일도 전처리 및 벡터화를 진행하도록 코드를 추가
- 이를 바탕으로 `load_to_supabase.py`를 통한 supabase 적재도 진행

## 실행 방법 

- 기존 `\FILES\preprocessed`에 중복 파일이 존재할 수 있으니 아래 코드를 실행 후, 두 코드를 재실행
  ```bash
  Remove-Item -Recurse -Force FILES\preprocessed\pdf\공지사항
  Remove-Item -Recurse -Force FILES\preprocessed\hwp\공지사항
  Remove-Item -Recurse -Force FILES\preprocessed\hwpx\공지사항
  Remove-Item -Recurse -Force FILES\preprocessed\docx\공지사항
  Remove-Item -Recurse -Force FILES\preprocessed\doc\공지사항
  ```
- 현재 supabase의 적재는 완료되어 있는 상태이나 만약 테이블 재 구성이 필요하다면, SQL Editor의 `Reset` 코드 실행 후 적재 