### PR TITLE
[Feat] 규정집 전체 파이프라인 구현

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -1,0 +1,315 @@
+# 명령어 정리
+
+이 문서는 프로젝트의 실행 스크립트별 역할과 자주 사용하는 CLI 옵션을 정리합니다.
+모든 명령은 저장소 루트에서 실행하는 것을 기준으로 합니다.
+
+## 권장 실행 환경
+
+```powershell
+.\.venv\Scripts\python.exe --version
+```
+
+터미널에 로그가 바로 보이게 실행하고 싶으면 `-u` 옵션을 사용합니다.
+
+```powershell
+.\.venv\Scripts\python.exe -u scripts/rule/crawler.py --laws --bylaws
+```
+
+로그를 실시간으로 확인하려면 다음 명령을 사용합니다.
+
+```powershell
+Get-Content logs\rule_crawler.log -Wait -Tail 30
+Get-Content logs\rule_preprocessing.log -Wait -Tail 30
+```
+
+## 컴퓨터공학부 파이프라인
+
+### `scripts/ce/crawler.py`
+
+컴퓨터·인공지능공학부 홈페이지를 크롤링합니다. 크롤링된 JSON, HTML, 첨부파일은 `files/ce/output` 아래에 저장됩니다.
+
+```powershell
+python scripts/ce/crawler.py --once
+```
+
+옵션:
+
+- `--once`: 스케줄링 없이 즉시 1회만 실행합니다.
+- `--reset-state`: `state.json`을 초기화하고 처음부터 다시 수집합니다.
+
+### `scripts/ce/preprocessing.py`
+
+컴퓨터공학부 크롤링 결과와 다운로드된 첨부파일을 RAG용 청크 JSON으로 전처리합니다.
+
+```powershell
+python scripts/ce/preprocessing.py
+```
+
+기본값:
+
+- `--input-root`: `files/ce/output/files`
+- `--output-root`: `files/ce/preprocessed`
+- `--output-json-root`: `files/ce/output/json`
+- `--chunk-size`: `900`
+- `--chunk-overlap`: `120`
+- `--pdf-ocr`: `auto`
+- `--ocr-language`: `kor+eng`
+- `--ocr-dpi`: `200`
+
+옵션:
+
+- `--input-root PATH`: 원본 첨부파일 루트 경로입니다.
+- `--output-root PATH`: 전처리 JSON 출력 루트 경로입니다.
+- `--output-json-root PATH`: 첨부파일 provenance 조인에 사용할 크롤링 JSON 루트입니다.
+- `--dry-run`: 실제 저장 없이 처리 대상만 확인합니다.
+- `--chunk-size N`: 청크 최대 문자 수입니다.
+- `--chunk-overlap N`: 연속 청크 사이의 문자 오버랩 길이입니다.
+- `--pdf-ocr auto|never|always`: PDF OCR fallback 사용 방식입니다.
+- `--ocr-language LANG`: Tesseract OCR 언어 설정입니다.
+- `--ocr-dpi N`: PDF 페이지를 OCR 이미지로 렌더링할 DPI입니다.
+
+## 규정집 파이프라인
+
+### `scripts/rule/crawler.py`
+
+국립부경대학교 규정집을 크롤링합니다. 규정 JSON, 원본 HTML, 첨부파일, 첨부파일 텍스트 추출 메타데이터를 `files/rule/output` 아래에 저장합니다.
+
+```powershell
+python scripts/rule/crawler.py --laws --bylaws
+```
+
+옵션:
+
+- `--laws`: 학칙/규정 트리의 항목을 크롤링합니다.
+- `--bylaws`: 지침/세칙 목록과 상세 페이지를 크롤링합니다.
+- `--download-files`: 첨부파일을 다운로드합니다. 기본값입니다.
+- `--no-download-files`: 첨부파일 다운로드와 첨부파일 텍스트 추출을 생략합니다.
+- `--max-law-items N`: 테스트용으로 학칙/규정 항목 수를 제한합니다.
+- `--max-bylaw-pages N`: 테스트용으로 지침/세칙 목록 페이지 수를 제한합니다.
+
+예시:
+
+```powershell
+python scripts/rule/crawler.py --laws --max-law-items 1
+python scripts/rule/crawler.py --bylaws --max-bylaw-pages 1
+python scripts/rule/crawler.py --laws --bylaws --no-download-files
+```
+
+### `scripts/rule/preprocessing.py`
+
+규정집 크롤링 산출물을 전처리합니다. JSON, HTML, 다운로드된 첨부파일을 모두 처리할 수 있습니다. 중복 텍스트는 허용하며, 출력 메타데이터의 `source_kind`로 `json`, `html`, `file` 출처를 구분합니다.
+
+```powershell
+python scripts/rule/preprocessing.py
+```
+
+기본값:
+
+- `--json-root`: `files/rule/output/json`
+- `--html-root`: `files/rule/output/html`
+- `--files-root`: `files/rule/output/files`
+- `--output-root`: `files/rule/preprocessed`
+- `--source-scope`: `all`
+- `--chunk-size`: `900`
+- `--chunk-overlap`: `120`
+
+출력 구조:
+
+```text
+files/rule/preprocessed/json/
+files/rule/preprocessed/html/
+files/rule/preprocessed/file/
+```
+
+옵션:
+
+- `--json-root PATH`: 규정집 크롤링 JSON 루트입니다.
+- `--html-root PATH`: 규정집 원본 HTML 루트입니다.
+- `--files-root PATH`: 규정집 다운로드 첨부파일 루트입니다.
+- `--output-root PATH`: 전처리 출력 루트입니다.
+- `--source-scope json|html|files|all`: 전처리할 산출물 종류를 선택합니다.
+- `--failed-from-log PATH`: 전처리 로그에서 `[FAIL:file]` 경로만 파싱해 실패한 첨부파일만 재처리합니다.
+- `--dry-run`: 실제 저장 없이 처리 대상만 확인합니다.
+- `--chunk-size N`: 청크 최대 문자 수입니다.
+- `--chunk-overlap N`: 연속 청크 사이의 문자 오버랩 길이입니다.
+
+예시:
+
+```powershell
+python scripts/rule/preprocessing.py --source-scope json
+python scripts/rule/preprocessing.py --source-scope html
+python scripts/rule/preprocessing.py --source-scope files
+python scripts/rule/preprocessing.py --failed-from-log logs\rule_preprocessing.log
+```
+
+## 벡터화
+
+### `scripts/rag/vectorization.py`
+
+전처리된 청크 JSON을 벡터화하고, 개별 벡터 파일과 `index.jsonl`을 생성합니다.
+
+컴퓨터공학부 기본 실행:
+
+```powershell
+python scripts/rag/vectorization.py --dataset ce --backend sentence-transformers
+```
+
+규정집 파이프라인 실행:
+
+```powershell
+python scripts/rag/vectorization.py --dataset rule --backend sentence-transformers
+```
+
+기본값:
+
+- `--dataset`: `ce`
+- `--dataset ce`: `files/ce/preprocessed` -> `files/ce/vectorized`
+- `--dataset rule`: `files/rule/preprocessed` -> `files/rule/vectorized`
+- `--backend`: `hash`
+- `--model-name`: `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`
+- `--dimensions`: `768` (`hash` backend 사용 시)
+- `--batch-size`: `32`
+
+옵션:
+
+- `--input-root PATH`: 전처리 JSON 루트입니다.
+- `--output-root PATH`: 벡터화 결과 출력 루트입니다.
+- `--dataset ce|rule`: 벡터화할 데이터셋 기본 경로를 선택합니다. `--input-root`, `--output-root`를 직접 지정하면 해당 경로가 우선합니다.
+- `--backend hash|sentence-transformers`: 임베딩 backend를 선택합니다.
+- `--model-name NAME`: `sentence-transformers` backend 사용 시 모델명입니다.
+- `--dimensions N`: `hash` backend 사용 시 임베딩 차원 수입니다.
+- `--batch-size N`: 임베딩 배치 크기입니다.
+- `--dry-run`: 실제 저장 없이 처리 대상만 확인합니다.
+
+Supabase 적재 전에는 `sentence-transformers` backend를 사용하는 것이 좋습니다. 현재 DB 스키마는 384차원 임베딩을 기준으로 합니다.
+
+## Supabase 적재
+
+### `scripts/rag/load_to_supabase.py`
+
+벡터화된 RAG 청크를 Supabase PostgreSQL 테이블에 적재합니다.
+
+컴퓨터공학부 기본 실행:
+
+```powershell
+python scripts/rag/load_to_supabase.py --dataset ce
+```
+
+규정집 파이프라인 실행:
+
+```powershell
+python scripts/rag/load_to_supabase.py --dataset rule
+```
+
+기본값:
+
+- `--dataset`: `ce`
+- `--dataset ce`: `files/ce/vectorized/index.jsonl` -> `rag_sources/rag_chunks`
+- `--dataset rule`: `files/rule/vectorized/index.jsonl` -> `rule_sources/rule_chunks`
+- `--batch-size`: `200`
+
+옵션:
+
+- `--dataset ce|rule`: 적재할 Supabase 테이블 preset을 선택합니다. `ce`는 `rag_sources/rag_chunks`, `rule`은 `rule_sources/rule_chunks`를 사용합니다.
+- `--index PATH`: 벡터화된 JSONL 인덱스 경로입니다. 지정하지 않으면 `--dataset`에 맞는 기본 index를 사용합니다.
+- `--sources-table NAME`: `public` schema 안의 source 테이블명을 직접 지정합니다.
+- `--chunks-table NAME`: `public` schema 안의 chunk 테이블명을 직접 지정합니다.
+- `--batch-size N`: DB insert 배치 크기입니다.
+
+필요한 환경 변수:
+
+- `DATABASE_URL` 또는 `SUPABASE_DB_URL`
+- 또는 `PGHOST`, `PGDATABASE`, `PGUSER`, `PGPASSWORD`
+- 선택: `PGPORT`, `PGSSLMODE`
+
+환경 변수는 `backend/.env`에서 로드됩니다.
+
+## Supabase 검색
+
+### `scripts/rag/query_supabase.py`
+
+Supabase에 적재된 RAG 청크를 대상으로 semantic search를 실행합니다.
+
+```powershell
+python scripts/rag/query_supabase.py "졸업 요건 알려줘" --dataset ce
+python scripts/rag/query_supabase.py "학칙의 휴학 규정을 알려줘" --dataset rule
+```
+
+기본값:
+
+- `--model-name`: `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`
+- `--dataset`: `ce`
+- `--top-k`: `5`
+- `--min-similarity`: `0.0`
+
+옵션:
+
+- positional `question`: 검색 질문입니다.
+- `--model-name NAME`: 질문 임베딩에 사용할 모델명입니다.
+- `--top-k N`: 반환할 검색 결과 수입니다.
+- `--min-similarity FLOAT`: 최소 유사도 기준입니다.
+
+## 컴퓨터공학부 스케줄 파이프라인
+
+### `scripts/rag/pipelining.py`
+
+`scripts/ce/crawler.py -> scripts/ce/preprocessing.py -> scripts/rag/vectorization.py -> scripts/rag/load_to_supabase.py` 순서로 실행합니다.
+이 스크립트는 컴퓨터공학부 파이프라인을 대상으로 하며, 규정집 파이프라인용은 아닙니다.
+
+1회 실행:
+
+```powershell
+python scripts/rag/pipelining.py --once
+```
+
+스케줄러 실행:
+
+```powershell
+python scripts/rag/pipelining.py --run-at 09:00
+```
+
+기본값:
+
+- `--run-at`: `09:00`
+- `--poll-seconds`: `30`
+- `--vector-backend`: `sentence-transformers`
+- `--vector-batch-size`: `32`
+- `--load-batch-size`: `200`
+- 기본적으로 스케줄러 시작 시 1회 즉시 실행합니다. 즉시 실행을 막으려면 `--no-run-on-start`를 사용합니다.
+
+옵션:
+
+- `--once`: 스케줄러 없이 전체 파이프라인을 1회 실행합니다.
+- `--run-on-start`: 시작 즉시 1회 실행한 뒤 스케줄러를 유지합니다. 기본값입니다.
+- `--no-run-on-start`: 즉시 실행 없이 스케줄러만 시작합니다.
+- `--run-at HH:MM`: 매일 실행할 시각입니다.
+- `--poll-seconds N`: 스케줄러 polling 간격입니다.
+- `--vector-backend sentence-transformers|hash`: `scripts/rag/vectorization.py`에 넘길 backend입니다.
+- `--vector-batch-size N`: `scripts/rag/vectorization.py`에 넘길 배치 크기입니다.
+- `--load-batch-size N`: `scripts/rag/load_to_supabase.py`에 넘길 배치 크기입니다.
+
+## 자주 쓰는 전체 실행 명령
+
+### 컴퓨터공학부
+
+```powershell
+python scripts/ce/crawler.py --once
+python scripts/ce/preprocessing.py
+python scripts/rag/vectorization.py --dataset ce --backend sentence-transformers
+python scripts/rag/load_to_supabase.py --dataset ce
+```
+
+### 규정집
+
+```powershell
+python scripts/rule/crawler.py --laws --bylaws
+python scripts/rule/preprocessing.py
+python scripts/rag/vectorization.py --dataset rule --backend sentence-transformers
+python scripts/rag/load_to_supabase.py --dataset rule
+```
+
+### 규정집 실패 첨부파일 재처리
+
+```powershell
+python scripts/rule/preprocessing.py --failed-from-log logs\rule_preprocessing.log
+```

--- a/docs/DATA_STRUCTURE.md
+++ b/docs/DATA_STRUCTURE.md
@@ -26,7 +26,7 @@ Default pipeline paths target `files/ce` to preserve the existing Computer Engin
 Rule crawling uses `files/rule` by default:
 
 ```powershell
-python rule_crawler.py --laws --bylaws
+python scripts/rule/crawler.py --laws --bylaws
 ```
 
 Rule attachments are downloaded by default. Use `--no-download-files` for a metadata-only crawl.
@@ -34,14 +34,25 @@ Rule attachments are downloaded by default. Use `--no-download-files` for a meta
 Rule JSON documents include both combined and source-specific text fields:
 
 - `content`: combined text used for downstream preprocessing.
+- `html_text`: text extracted from the crawled HTML body/detail area.
 - `page_content`: text visible in the detail page body.
 - `preview_content`: preview HTML text when the site exposes it separately.
 - `attachment_texts`: extracted text from downloaded attachments, with extraction errors kept per file.
 
-To preprocess and vectorize rule attachments separately:
+To preprocess and vectorize all rule artifacts (`json`, `html`, and downloaded `files`):
 
 ```powershell
-python preprocessing.py --input-root files/rule/output/files --output-root files/rule/preprocessed --output-json-root files/rule/output/json
-python vectorization.py --input-root files/rule/preprocessed --output-root files/rule/vectorized --backend sentence-transformers
-python load_to_supabase.py --index-path files/rule/vectorized/index.jsonl
+python scripts/rule/preprocessing.py
+python scripts/rag/vectorization.py --dataset rule --backend sentence-transformers
+python scripts/rag/load_to_supabase.py --dataset rule
+```
+
+`scripts/rule/preprocessing.py` writes separate preprocessed trees under `files/rule/preprocessed/json`, `files/rule/preprocessed/html`, and `files/rule/preprocessed/file`. Duplicate text is allowed; every chunk keeps `source_kind` metadata so JSON, HTML, and attachment-derived records can still be distinguished.
+
+To preprocess only one artifact type:
+
+```powershell
+python scripts/rule/preprocessing.py --source-scope json
+python scripts/rule/preprocessing.py --source-scope html
+python scripts/rule/preprocessing.py --source-scope files
 ```

--- a/scripts/ce/crawler.py
+++ b/scripts/ce/crawler.py
@@ -17,8 +17,8 @@ https://ce.pknu.ac.kr/ce/1
   - 최초 실행은 INITIAL_MAX_PAGES 페이지까지만 수집
 
 실행:
-  - python crawler.py
-  - python crawler.py --once
+  - python scripts/ce/crawler.py
+  - python scripts/ce/crawler.py --once
 """
 
 import argparse
@@ -40,7 +40,8 @@ from requests.adapters import HTTPAdapter
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-LOG_DIR = Path(__file__).resolve().parent / "logs"
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+LOG_DIR = PROJECT_ROOT / "logs"
 LOG_DIR.mkdir(parents=True, exist_ok=True)
 
 # ─── 로깅 설정 ────────────────────────────────────────────────────────────────
@@ -56,10 +57,10 @@ log = logging.getLogger(__name__)
 
 # ─── 경로 및 상수 ─────────────────────────────────────────────────────────────
 BASE_URL = "https://ce.pknu.ac.kr"
-OUTPUT_JSON = Path("files/ce/output/json")
-OUTPUT_HTML = Path("files/ce/output/html")
-OUTPUT_FILES = Path("files/ce/output/files")
-STATE_FILE = Path("state.json")
+OUTPUT_JSON = PROJECT_ROOT / "files" / "ce" / "output" / "json"
+OUTPUT_HTML = PROJECT_ROOT / "files" / "ce" / "output" / "html"
+OUTPUT_FILES = PROJECT_ROOT / "files" / "ce" / "output" / "files"
+STATE_FILE = PROJECT_ROOT / "state.json"
 
 REQUEST_DELAY = 0.8
 LIST_DELAY = 0.5

--- a/scripts/ce/preprocessing.py
+++ b/scripts/ce/preprocessing.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 log = logging.getLogger(__name__)
 
-PROJECT_ROOT = Path(__file__).resolve().parent
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
 LOG_DIR = PROJECT_ROOT / "logs"
 LOG_FILE = LOG_DIR / "preprocessing.log"
 
@@ -54,6 +54,7 @@ DEFAULT_PDF_OCR_MODE = "auto"
 DEFAULT_OCR_LANGUAGE = "kor+eng"
 DEFAULT_OCR_DPI = 200
 MIN_USEFUL_PDF_TEXT_CHARS = 80
+HWP_EXTRACT_TIMEOUT = 60
 
 
 def normalize_text(text: str) -> str:
@@ -722,14 +723,19 @@ def extract_hwp_blocks(path: Path) -> list[dict]:
         html_file = tmp_base / f"{token}.xhtml"
         try:
             shutil.copy2(path, copied_hwp)
-            proc = subprocess.run(
-                [hwp5html, "--html", "--output", str(html_file), str(copied_hwp)],
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="ignore",
-                check=False,
-            )
+            try:
+                proc = subprocess.run(
+                    [hwp5html, "--html", "--output", str(html_file), str(copied_hwp)],
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    errors="ignore",
+                    check=False,
+                    timeout=HWP_EXTRACT_TIMEOUT,
+                )
+            except subprocess.TimeoutExpired:
+                log.warning("hwp5html timed out for %s; falling back to hwp5txt", path)
+                return []
             if proc.returncode != 0:
                 log.debug("hwp5html failed for %s: %s", path, format_hwp_runtime_error(proc.stderr))
                 return []
@@ -842,6 +848,7 @@ def extract_hwp_blocks(path: Path) -> list[dict]:
         encoding="utf-8",
         errors="ignore",
         check=False,
+        timeout=HWP_EXTRACT_TIMEOUT,
     )
     if proc.returncode != 0:
         raise RuntimeError(f"hwp5txt failed: {format_hwp_runtime_error(proc.stderr)}")
@@ -1106,7 +1113,7 @@ def run_batch(
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="FILES/output의 게시글 JSON과 첨부 원문파일을 RAG용 전처리 JSON으로 변환"
+        description="files/ce/output의 게시글 JSON과 첨부 원문파일을 RAG용 전처리 JSON으로 변환"
     )
     parser.add_argument(
         "--input-root",

--- a/scripts/rag/load_to_supabase.py
+++ b/scripts/rag/load_to_supabase.py
@@ -17,6 +17,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -25,12 +26,25 @@ from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 import psycopg
 from dotenv import load_dotenv
+from psycopg import sql
 from psycopg.types.json import Jsonb
 
-DEFAULT_INDEX_PATH = Path("files/ce/vectorized/index.jsonl")
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DATASET_TABLES = {
+    "ce": {
+        "index": PROJECT_ROOT / "files" / "ce" / "vectorized" / "index.jsonl",
+        "sources": "rag_sources",
+        "chunks": "rag_chunks",
+    },
+    "rule": {
+        "index": PROJECT_ROOT / "files" / "rule" / "vectorized" / "index.jsonl",
+        "sources": "rule_sources",
+        "chunks": "rule_chunks",
+    },
+}
+DEFAULT_DATASET = "ce"
 EXPECTED_DIMENSIONS = 384
 DEFAULT_EMBEDDING_MODEL = "sentence-transformers:sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
-PROJECT_ROOT = Path(__file__).resolve().parent
 LOG_DIR = PROJECT_ROOT / "logs"
 LOG_FILE = LOG_DIR / "load_to_supabase.log"
 
@@ -97,27 +111,51 @@ def connect() -> psycopg.Connection:
     )
 
 
-def ensure_schema_ready(conn: psycopg.Connection) -> None:
+def validate_table_name(value: str) -> str:
+    if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", value):
+        raise ValueError(f"Invalid table name: {value}")
+    return value
+
+
+def resolve_tables(
+    dataset: str,
+    sources_table: str | None,
+    chunks_table: str | None,
+) -> tuple[str, str]:
+    defaults = DATASET_TABLES[dataset]
+    return (
+        validate_table_name(sources_table or defaults["sources"]),
+        validate_table_name(chunks_table or defaults["chunks"]),
+    )
+
+
+def resolve_index_path(dataset: str, index_path: Path | None) -> Path:
+    if index_path is not None:
+        return index_path
+    return DATASET_TABLES[dataset]["index"]
+
+
+def ensure_schema_ready(conn: psycopg.Connection, sources_table: str, chunks_table: str) -> None:
     log.info("Checking Supabase schema")
     sql = """
         select
-            to_regclass('public.rag_sources') is not null as has_sources,
-            to_regclass('public.rag_chunks') is not null as has_chunks
+            to_regclass(%s) is not null as has_sources,
+            to_regclass(%s) is not null as has_chunks
     """
     with conn.cursor() as cur:
-        cur.execute(sql)
+        cur.execute(sql, (f"public.{sources_table}", f"public.{chunks_table}"))
         has_sources, has_chunks = cur.fetchone()
 
     missing = []
     if not has_sources:
-        missing.append("public.rag_sources")
+        missing.append(f"public.{sources_table}")
     if not has_chunks:
-        missing.append("public.rag_chunks")
+        missing.append(f"public.{chunks_table}")
     if missing:
         raise RuntimeError(
             "Supabase schema is not ready. Missing tables: "
-            f"{', '.join(missing)}. Apply supabase/migrations/002_split_rag_documents.sql "
-            "before running load_to_supabase.py."
+            f"{', '.join(missing)}. Apply the matching migration under supabase/migrations "
+            "before running scripts/rag/load_to_supabase.py."
         )
 
 
@@ -178,7 +216,7 @@ def prepare_row(record: dict[str, Any], embedding_model: str) -> dict[str, dict[
     if len(embedding) != EXPECTED_DIMENSIONS:
         raise ValueError(
             f"Record {record.get('id')} has embedding dimension {len(embedding)}, "
-            f"expected {EXPECTED_DIMENSIONS}. Re-run: python vectorization.py --backend sentence-transformers"
+            f"expected {EXPECTED_DIMENSIONS}. Re-run: python scripts/rag/vectorization.py --backend sentence-transformers"
         )
 
     content = remove_nul_bytes(record.get("text") or record.get("content") or "")
@@ -224,12 +262,17 @@ def prepare_row(record: dict[str, Any], embedding_model: str) -> dict[str, dict[
     }
 
 
-def flush_batch(conn: psycopg.Connection, rows: list[dict[str, dict[str, Any]]]) -> None:
+def flush_batch(
+    conn: psycopg.Connection,
+    rows: list[dict[str, dict[str, Any]]],
+    sources_table: str,
+    chunks_table: str,
+) -> None:
     if not rows:
         return
 
-    source_sql = """
-        insert into public.rag_sources (
+    source_sql = sql.SQL("""
+        insert into {sources_table} (
             id, source_slug, source_type, title, url, parent_url, file_path,
             file_ext, category, subcategory, metadata, processed_at
         )
@@ -250,9 +293,9 @@ def flush_batch(conn: psycopg.Connection, rows: list[dict[str, dict[str, Any]]])
             subcategory = excluded.subcategory,
             metadata = excluded.metadata,
             processed_at = excluded.processed_at
-    """
-    chunk_sql = """
-        insert into public.rag_chunks (
+    """).format(sources_table=sql.Identifier("public", sources_table))
+    chunk_sql = sql.SQL("""
+        insert into {chunks_table} (
             id, source_id, chunk_id, chunk_index, content, content_hash,
             token_count, metadata, embedding, embedding_model, embedding_dim, embedded_at
         )
@@ -283,7 +326,7 @@ def flush_batch(conn: psycopg.Connection, rows: list[dict[str, dict[str, Any]]])
             embedding_model = excluded.embedding_model,
             embedding_dim = excluded.embedding_dim,
             embedded_at = excluded.embedded_at
-    """
+    """).format(chunks_table=sql.Identifier("public", chunks_table))
     sources = {row["source"]["id"]: row["source"] for row in rows}
     chunks = [row["chunk"] for row in rows]
     with conn.cursor() as cur:
@@ -291,27 +334,39 @@ def flush_batch(conn: psycopg.Connection, rows: list[dict[str, dict[str, Any]]])
         cur.executemany(chunk_sql, chunks)
 
 
-def load(index_path: Path, batch_size: int) -> int:
+def load(
+    index_path: Path,
+    batch_size: int,
+    dataset: str,
+    sources_table: str | None = None,
+    chunks_table: str | None = None,
+) -> int:
     if not index_path.exists():
         raise FileNotFoundError(f"Index file not found: {index_path}")
 
+    resolved_sources_table, resolved_chunks_table = resolve_tables(
+        dataset,
+        sources_table,
+        chunks_table,
+    )
     embedding_model = load_embedding_model(index_path)
     log.info("Loading Supabase rows from %s", index_path)
+    log.info("target tables: public.%s, public.%s", resolved_sources_table, resolved_chunks_table)
     log.info("embedding model: %s", embedding_model)
     total = 0
     batch: list[dict[str, dict[str, Any]]] = []
     with connect() as conn:
-        ensure_schema_ready(conn)
+        ensure_schema_ready(conn, resolved_sources_table, resolved_chunks_table)
         for record in iter_records(index_path):
             batch.append(prepare_row(record, embedding_model))
             if len(batch) >= batch_size:
-                flush_batch(conn, batch)
+                flush_batch(conn, batch, resolved_sources_table, resolved_chunks_table)
                 total += len(batch)
                 conn.commit()
                 log.info("upserted %d rows", total)
                 batch.clear()
 
-        flush_batch(conn, batch)
+        flush_batch(conn, batch, resolved_sources_table, resolved_chunks_table)
         total += len(batch)
         conn.commit()
 
@@ -321,11 +376,21 @@ def load(index_path: Path, batch_size: int) -> int:
 def main() -> None:
     configure_logging()
     parser = argparse.ArgumentParser(description="Load RAG chunks into Supabase PostgreSQL.")
-    parser.add_argument("--index", type=Path, default=DEFAULT_INDEX_PATH)
+    parser.add_argument("--index", type=Path, default=None)
+    parser.add_argument("--dataset", choices=sorted(DATASET_TABLES), default=DEFAULT_DATASET)
+    parser.add_argument("--sources-table", help="Override source table name in public schema.")
+    parser.add_argument("--chunks-table", help="Override chunk table name in public schema.")
     parser.add_argument("--batch-size", type=int, default=200)
     args = parser.parse_args()
 
-    count = load(args.index, args.batch_size)
+    index_path = resolve_index_path(args.dataset, args.index)
+    count = load(
+        index_path,
+        args.batch_size,
+        args.dataset,
+        args.sources_table,
+        args.chunks_table,
+    )
     log.info("done: upserted %d rows", count)
 
 

--- a/scripts/rag/pipelining.py
+++ b/scripts/rag/pipelining.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import schedule
 
 
-PROJECT_ROOT = Path(__file__).resolve().parent
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_RUN_AT = "09:00"
 LOG_DIR = PROJECT_ROOT / "logs"
 LOG_FILE = LOG_DIR / "daily_pipeline.log"
@@ -54,13 +54,15 @@ def run_pipeline(args: argparse.Namespace) -> None:
 
     try:
         python = sys.executable
-        run_command("crawler", [python, "crawler.py", "--once"])
-        run_command("preprocessing", [python, "preprocessing.py"])
+        run_command("crawler", [python, "scripts/ce/crawler.py", "--once"])
+        run_command("preprocessing", [python, "scripts/ce/preprocessing.py"])
         run_command(
             "vectorization",
             [
                 python,
-                "vectorization.py",
+                "scripts/rag/vectorization.py",
+                "--dataset",
+                "ce",
                 "--backend",
                 args.vector_backend,
                 "--batch-size",
@@ -69,7 +71,14 @@ def run_pipeline(args: argparse.Namespace) -> None:
         )
         run_command(
             "load_to_supabase",
-            [python, "load_to_supabase.py", "--batch-size", str(args.load_batch_size)],
+            [
+                python,
+                "scripts/rag/load_to_supabase.py",
+                "--dataset",
+                "ce",
+                "--batch-size",
+                str(args.load_batch_size),
+            ],
         )
 
         elapsed = (datetime.now() - started_at).total_seconds()
@@ -104,8 +113,8 @@ def run_scheduler(args: argparse.Namespace) -> None:
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
-            "Run crawler.py -> preprocessing.py -> vectorization.py -> "
-            "load_to_supabase.py every day at 09:00."
+            "Run scripts/ce/crawler.py -> scripts/ce/preprocessing.py -> "
+            "scripts/rag/vectorization.py -> scripts/rag/load_to_supabase.py every day at 09:00."
         )
     )
     parser.add_argument(
@@ -142,21 +151,21 @@ def parse_args() -> argparse.Namespace:
         choices=["sentence-transformers", "hash"],
         default="sentence-transformers",
         help=(
-            "Embedding backend for vectorization.py. Default is sentence-transformers "
-            "because load_to_supabase.py expects 384-dimensional embeddings."
+            "Embedding backend for scripts/rag/vectorization.py. Default is sentence-transformers "
+            "because scripts/rag/load_to_supabase.py expects 384-dimensional embeddings."
         ),
     )
     parser.add_argument(
         "--vector-batch-size",
         type=int,
         default=32,
-        help="Batch size passed to vectorization.py. Default: 32.",
+        help="Batch size passed to scripts/rag/vectorization.py. Default: 32.",
     )
     parser.add_argument(
         "--load-batch-size",
         type=int,
         default=200,
-        help="Batch size passed to load_to_supabase.py. Default: 200.",
+        help="Batch size passed to scripts/rag/load_to_supabase.py. Default: 200.",
     )
     return parser.parse_args()
 

--- a/scripts/rag/query_supabase.py
+++ b/scripts/rag/query_supabase.py
@@ -4,17 +4,23 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import sys
 from pathlib import Path
 from typing import Any
 
 import psycopg
 from dotenv import load_dotenv
+from psycopg import sql
 from psycopg.rows import dict_row
 
-PROJECT_ROOT = Path(__file__).resolve().parent
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_MODEL = "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
 EXPECTED_DIMENSIONS = 384
+DATASET_MATCH_FUNCTIONS = {
+    "ce": "match_rag_documents",
+    "rule": "match_rule_documents",
+}
 
 
 def connect() -> psycopg.Connection:
@@ -65,21 +71,35 @@ def vector_literal(values: list[float]) -> str:
     return "[" + ",".join(str(float(value)) for value in values) + "]"
 
 
-def search(question: str, model_name: str, top_k: int, min_similarity: float) -> list[dict[str, Any]]:
+def validate_function_name(value: str) -> str:
+    if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", value):
+        raise ValueError(f"Invalid function name: {value}")
+    return value
+
+
+def search(
+    question: str,
+    model_name: str,
+    top_k: int,
+    min_similarity: float,
+    dataset: str,
+    match_function: str | None = None,
+) -> list[dict[str, Any]]:
     embedding = vector_literal(embed_query(question, model_name))
-    sql = """
+    function_name = validate_function_name(match_function or DATASET_MATCH_FUNCTIONS[dataset])
+    query = sql.SQL("""
         select *
-        from public.match_rag_documents(
+        from {match_function}(
             %(embedding)s::extensions.vector(384),
             %(top_k)s,
             %(min_similarity)s,
-            '{}'::jsonb
+            '{{}}'::jsonb
         )
-    """
+    """).format(match_function=sql.Identifier("public", function_name))
     with connect() as conn:
         with conn.cursor() as cur:
             cur.execute(
-                sql,
+                query,
                 {
                     "embedding": embedding,
                     "top_k": top_k,
@@ -118,12 +138,21 @@ def main() -> None:
 
     parser = argparse.ArgumentParser(description="Semantic search against Supabase RAG chunks.")
     parser.add_argument("question")
+    parser.add_argument("--dataset", choices=sorted(DATASET_MATCH_FUNCTIONS), default="ce")
+    parser.add_argument("--match-function", help="Override public schema match function name.")
     parser.add_argument("--model-name", default=DEFAULT_MODEL)
     parser.add_argument("--top-k", type=int, default=5)
     parser.add_argument("--min-similarity", type=float, default=0.0)
     args = parser.parse_args()
 
-    rows = search(args.question, args.model_name, args.top_k, args.min_similarity)
+    rows = search(
+        args.question,
+        args.model_name,
+        args.top_k,
+        args.min_similarity,
+        args.dataset,
+        args.match_function,
+    )
     print_results(rows)
 
 

--- a/scripts/rag/vectorization.py
+++ b/scripts/rag/vectorization.py
@@ -10,13 +10,13 @@
    실행 요약인 /files/ce/vectorized/manifest.json을 함께 만든다.
 
 기본 실행:
-    python vectorization.py
+    python scripts/rag/vectorization.py
 
 실행 전 파일 확인:
-    python vectorization.py --dry-run
+    python scripts/rag/vectorization.py --dry-run
 
 sentence-transformers 사용:
-    python vectorization.py --backend sentence-transformers
+    python scripts/rag/vectorization.py --backend sentence-transformers
 """
 
 from __future__ import annotations
@@ -35,7 +35,7 @@ from typing import Iterable, Protocol
 
 log = logging.getLogger(__name__)
 
-PROJECT_ROOT = Path(__file__).resolve().parent
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
 LOG_DIR = PROJECT_ROOT / "logs"
 LOG_FILE = LOG_DIR / "vectorization.log"
 
@@ -52,8 +52,17 @@ def configure_logging() -> None:
     )
 
 # CLI 기본값: 입력/출력 경로와 임베딩 방식 설정.
-DEFAULT_INPUT_ROOT = Path("files/ce/preprocessed")
-DEFAULT_OUTPUT_ROOT = Path("files/ce/vectorized")
+DATASET_PATHS = {
+    "ce": {
+        "input_root": PROJECT_ROOT / "files" / "ce" / "preprocessed",
+        "output_root": PROJECT_ROOT / "files" / "ce" / "vectorized",
+    },
+    "rule": {
+        "input_root": PROJECT_ROOT / "files" / "rule" / "preprocessed",
+        "output_root": PROJECT_ROOT / "files" / "rule" / "vectorized",
+    },
+}
+DEFAULT_DATASET = "ce"
 DEFAULT_BACKEND = "hash"
 DEFAULT_DIMENSIONS = 768
 DEFAULT_BATCH_SIZE = 32
@@ -230,6 +239,15 @@ def make_embedder(args: argparse.Namespace) -> Embedder:
     raise ValueError(f"unsupported backend: {args.backend}")
 
 
+def resolve_vector_roots(args: argparse.Namespace) -> tuple[Path, Path]:
+    """데이터셋 기본 경로를 사용하되, CLI에서 직접 지정한 경로를 우선한다."""
+
+    dataset_paths = DATASET_PATHS[args.dataset]
+    input_root = args.input_root or dataset_paths["input_root"]
+    output_root = args.output_root or dataset_paths["output_root"]
+    return input_root, output_root
+
+
 def extract_chunk_records(doc: dict, input_file: Path, project_root: Path) -> list[dict]:
     """전처리 청크를 아직 embedding이 없는 검색 record로 변환한다."""
 
@@ -246,6 +264,7 @@ def extract_chunk_records(doc: dict, input_file: Path, project_root: Path) -> li
         "source_path": doc.get("source_path", ""),
         "source_relative_to_input": doc.get("source_relative_to_input", ""),
         "source_ext": doc.get("source_ext", ""),
+        "source_kind": doc.get("source_kind", provenance.get("source_kind", "")),
         "preprocessed_path": rel_project_path(input_file, project_root),
         "doc_title": provenance.get("doc_title", ""),
         "doc_url": provenance.get("doc_url", ""),
@@ -259,6 +278,9 @@ def extract_chunk_records(doc: dict, input_file: Path, project_root: Path) -> li
         "attachment_url": provenance.get("attachment_url", ""),
         "source_page_url": provenance.get("source_page_url", ""),
         "source_site": provenance.get("source_site", ""),
+        "source_json_path": provenance.get("source_json_path", ""),
+        "source_html_path": provenance.get("source_html_path", ""),
+        "source_attachment_path": provenance.get("source_attachment_path", ""),
     }
 
     records: list[dict] = []
@@ -343,6 +365,7 @@ def run_batch(
     embedder: Embedder,
     batch_size: int,
     dry_run: bool,
+    dataset: str,
 ) -> None:
     """입력 폴더 아래의 모든 전처리 JSON 파일을 벡터화한다."""
 
@@ -398,6 +421,7 @@ def run_batch(
     # manifest는 이번 벡터화 실행 결과를 추적하기 위한 요약 파일이다.
     manifest = {
         "vectorized_at": datetime.now().isoformat(),
+        "dataset": dataset,
         "input_root": rel_project_path(input_root, project_root),
         "output_root": rel_project_path(output_root, project_root),
         "embedding_backend": embedder.name,
@@ -425,16 +449,26 @@ def main() -> None:
         description="Vectorize preprocessed chunk JSON files for RAG retrieval."
     )
     parser.add_argument(
+        "--dataset",
+        choices=sorted(DATASET_PATHS),
+        default=DEFAULT_DATASET,
+        help=(
+            "Dataset path preset to vectorize. "
+            "Use ce for files/ce/preprocessed -> files/ce/vectorized, "
+            "or rule for files/rule/preprocessed -> files/rule/vectorized."
+        ),
+    )
+    parser.add_argument(
         "--input-root",
         type=Path,
-        default=DEFAULT_INPUT_ROOT,
-        help="Preprocessed JSON root directory.",
+        default=None,
+        help="Preprocessed JSON root directory. Overrides --dataset input path.",
     )
     parser.add_argument(
         "--output-root",
         type=Path,
-        default=DEFAULT_OUTPUT_ROOT,
-        help="Vectorized output root directory.",
+        default=None,
+        help="Vectorized output root directory. Overrides --dataset output path.",
     )
     parser.add_argument(
         "--backend",
@@ -472,15 +506,17 @@ def main() -> None:
         raise ValueError("--batch-size must be positive")
 
     # 현재 작업 디렉터리를 프로젝트 루트로 사용한다.
-    project_root = Path.cwd()
+    project_root = PROJECT_ROOT
+    input_root, output_root = resolve_vector_roots(args)
     embedder = HashEmbedder(1) if args.dry_run else make_embedder(args)
     run_batch(
-        input_root=args.input_root,
-        output_root=args.output_root,
+        input_root=input_root,
+        output_root=output_root,
         project_root=project_root,
         embedder=embedder,
         batch_size=args.batch_size,
         dry_run=args.dry_run,
+        dataset=args.dataset,
     )
 
 

--- a/scripts/rule/crawler.py
+++ b/scripts/rule/crawler.py
@@ -19,6 +19,7 @@ import hashlib
 import json
 import logging
 import re
+import ssl
 import sys
 import time
 import zipfile
@@ -30,15 +31,17 @@ from urllib.parse import parse_qsl, unquote, urlencode, urljoin, urlsplit, urlun
 
 import requests
 from bs4 import BeautifulSoup
+from requests.adapters import HTTPAdapter
 
 BASE_URL = "https://www.pknu.ac.kr"
 RULE_URL = f"{BASE_URL}/rule"
 LAW_URL = "https://www.law.go.kr"
 
-OUTPUT_JSON = Path("files/rule/output/json")
-OUTPUT_HTML = Path("files/rule/output/html")
-OUTPUT_FILES = Path("files/rule/output/files")
-LOG_DIR = Path(__file__).resolve().parent / "logs"
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+OUTPUT_JSON = PROJECT_ROOT / "files" / "rule" / "output" / "json"
+OUTPUT_HTML = PROJECT_ROOT / "files" / "rule" / "output" / "html"
+OUTPUT_FILES = PROJECT_ROOT / "files" / "rule" / "output" / "files"
+LOG_DIR = PROJECT_ROOT / "logs"
 LOG_FILE = LOG_DIR / "rule_crawler.log"
 
 REQUEST_TIMEOUT = 30
@@ -82,6 +85,18 @@ STATIC_EXTENSIONS = {
     ".ttf",
     ".eot",
 }
+
+
+class PknuSslAdapter(HTTPAdapter):
+    """Allow the current PKNU rule server TLS configuration with OpenSSL 3."""
+
+    def init_poolmanager(self, *args: Any, **kwargs: Any) -> None:
+        context = ssl.create_default_context()
+        context.set_ciphers("DEFAULT@SECLEVEL=1")
+        kwargs["ssl_context"] = context
+        return super().init_poolmanager(*args, **kwargs)
+
+
 GENERIC_ATTACHMENT_NAMES = {
     "attachment",
     "download",
@@ -131,6 +146,7 @@ def configure_logging() -> None:
 
 def build_session() -> requests.Session:
     session = requests.Session()
+    session.mount(BASE_URL, PknuSslAdapter())
     session.headers.update(
         {
             "User-Agent": (
@@ -614,13 +630,15 @@ def crawl_law_node(
 
     slug = slug_for("law", node.lid, node.title)
     attachment_texts: list[dict[str, Any]] = []
+    file_preview_texts: list[dict[str, Any]] = []
     if download_files:
         attachments = save_attachments(session, attachments, "pknu_rule_law", slug)
         attachment_texts = extract_attachment_texts(attachments)
+        file_preview_texts = build_file_preview_texts(attachment_texts)
     combined_content = dedupe_join_texts(
         content,
         *(preview.get("text", "") for preview in preview_texts),
-        *(preview.get("text", "") for preview in attachment_texts),
+        *(preview.get("text", "") for preview in file_preview_texts),
     )
 
     doc = {
@@ -638,10 +656,13 @@ def crawl_law_node(
         "issued_at": node.issue,
         "effective_at": node.effective,
         "content": combined_content,
+        "html_text": content,
+        "html_text_source": "law_ajax_html",
         "page_content": content,
         "preview_texts": preview_texts,
         "attachments": attachments,
         "attachment_texts": attachment_texts,
+        "file_preview_texts": file_preview_texts,
         "crawled_at": datetime.now().isoformat(timespec="seconds"),
     }
     save_document(doc, ajax_resp.text, "pknu_rule_law")
@@ -768,6 +789,16 @@ def extract_attachment_texts(attachments: list[dict[str, str]]) -> list[dict[str
     return previews
 
 
+def build_file_preview_texts(attachment_texts: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    file_previews: list[dict[str, Any]] = []
+    for attachment_text in attachment_texts:
+        preview = dict(attachment_text)
+        preview["source"] = "downloaded_attachment"
+        preview["preview_equivalent"] = True
+        file_previews.append(preview)
+    return file_previews
+
+
 def load_bylaw_preview_map(session: requests.Session) -> dict[str, dict[str, str]]:
     url = f"{RULE_URL}/byRows.do"
     try:
@@ -844,9 +875,11 @@ def crawl_bylaw_item(
     slug = slug_for("bylaw", item.bbs_id, item.board_seq, detail["title"])
     attachments = detail["attachments"]
     attachment_texts: list[dict[str, Any]] = []
+    file_preview_texts: list[dict[str, Any]] = []
     if download_files:
         attachments = save_attachments(session, attachments, "pknu_rule_bylaw", slug)
         attachment_texts = extract_attachment_texts(attachments)
+        file_preview_texts = build_file_preview_texts(attachment_texts)
 
     preview_entry = preview_entry or {}
     preview_content = preview_entry.get("content", "")
@@ -854,7 +887,7 @@ def crawl_bylaw_item(
         detail["content"],
         preview_content,
         *(preview.get("text", "") for preview in preview_texts),
-        *(preview.get("text", "") for preview in attachment_texts),
+        *(preview.get("text", "") for preview in file_preview_texts),
     )
 
     doc = {
@@ -870,6 +903,8 @@ def crawl_bylaw_item(
         "bbs_id": item.bbs_id,
         "author": detail["author"],
         "content": combined_content,
+        "html_text": detail["content"],
+        "html_text_source": "pknu_detail_html",
         "page_content": detail["content"],
         "content_html": detail["content_html"],
         "preview_content": preview_content,
@@ -879,6 +914,7 @@ def crawl_bylaw_item(
         "point_text": preview_entry.get("point_text", ""),
         "attachments": attachments,
         "attachment_texts": attachment_texts,
+        "file_preview_texts": file_preview_texts,
         "crawled_at": datetime.now().isoformat(timespec="seconds"),
     }
     save_document(doc, resp.text, "pknu_rule_bylaw")

--- a/scripts/rule/preprocessing.py
+++ b/scripts/rule/preprocessing.py
@@ -1,0 +1,664 @@
+"""Preprocess crawled PKNU rule artifacts for RAG.
+
+The rule crawler stores three useful artifact types:
+    1. JSON documents with crawler-normalized text fields.
+    2. Raw HTML snapshots.
+    3. Downloaded attachments.
+
+This script can preprocess all three.  Duplicate text is allowed by design; each
+output keeps a source_kind value so retrieval/debugging can distinguish where a
+chunk came from.
+
+Default inputs:
+    files/rule/output/json
+    files/rule/output/html
+    files/rule/output/files
+
+Default output:
+    files/rule/preprocessed
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from bs4 import BeautifulSoup
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_INPUT_ROOT = PROJECT_ROOT / "files" / "rule" / "output" / "json"
+DEFAULT_HTML_ROOT = PROJECT_ROOT / "files" / "rule" / "output" / "html"
+DEFAULT_FILES_ROOT = PROJECT_ROOT / "files" / "rule" / "output" / "files"
+DEFAULT_OUTPUT_ROOT = PROJECT_ROOT / "files" / "rule" / "preprocessed"
+LOG_DIR = PROJECT_ROOT / "logs"
+LOG_FILE = LOG_DIR / "rule_preprocessing.log"
+
+DEFAULT_CHUNK_SIZE = 900
+DEFAULT_CHUNK_OVERLAP = 120
+SUPPORTED_ATTACHMENT_EXTS = {".pdf", ".docx", ".doc", ".hwp", ".hwpx", ".csv", ".txt"}
+
+log = logging.getLogger(__name__)
+
+
+def configure_logging() -> None:
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        handlers=[
+            logging.StreamHandler(sys.stdout),
+            logging.FileHandler(LOG_FILE, encoding="utf-8"),
+        ],
+    )
+
+
+def normalize_text(text: object) -> str:
+    if text is None:
+        return ""
+    value = str(text)
+    value = value.replace("\u00a0", " ")
+    value = re.sub(r"\s+", " ", value)
+    return value.strip()
+
+
+def rel_project_path(path: Path, root: Path = PROJECT_ROOT) -> str:
+    try:
+        return path.resolve().relative_to(root.resolve()).as_posix()
+    except ValueError:
+        return path.resolve().as_posix()
+
+
+def stable_slug(*parts: object) -> str:
+    raw = "|".join(normalize_text(part) for part in parts)
+    return hashlib.md5(raw.encode("utf-8")).hexdigest()[:12]
+
+
+def output_path_for(input_file: Path, input_root: Path, output_root: Path) -> Path:
+    rel = input_file.resolve().relative_to(input_root.resolve())
+    return (output_root / rel).with_suffix(".json")
+
+
+def load_rule_json_index(json_root: Path) -> tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]]]:
+    docs_by_key: dict[str, dict[str, Any]] = {}
+    attachments_by_path: dict[str, dict[str, Any]] = {}
+    if not json_root.exists():
+        return docs_by_key, attachments_by_path
+
+    for json_path in json_root.rglob("*.json"):
+        try:
+            doc = json.loads(json_path.read_text(encoding="utf-8-sig"))
+        except Exception:
+            continue
+        if not isinstance(doc, dict):
+            continue
+
+        category = normalize_text(doc.get("category"))
+        slug = normalize_text(doc.get("slug")) or json_path.stem
+        key = f"{category}/{slug}" if category else slug
+        doc_info = {
+            **build_provenance(doc, json_path),
+            "source_json_path": rel_project_path(json_path),
+        }
+        docs_by_key[key] = doc_info
+
+        for attachment in doc.get("attachments", []) or []:
+            if not isinstance(attachment, dict):
+                continue
+            saved_path = normalize_text(attachment.get("saved_path"))
+            if not saved_path:
+                continue
+            abs_path = (PROJECT_ROOT / saved_path).resolve()
+            attachments_by_path[abs_path.as_posix().lower()] = {
+                **doc_info,
+                "attachment_name": attachment.get("name", ""),
+                "attachment_url": attachment.get("url", ""),
+                "downloaded_from_url": attachment.get("downloaded_from_url", ""),
+                "content_type": attachment.get("content_type", ""),
+            }
+
+    return docs_by_key, attachments_by_path
+
+
+def html_path_for(doc: dict[str, Any], html_root: Path) -> Path | None:
+    category = normalize_text(doc.get("category"))
+    slug = normalize_text(doc.get("slug"))
+    if not category or not slug:
+        return None
+    path = html_root / category / f"{slug}.html"
+    return path if path.exists() else None
+
+
+def extract_rule_html_text(path: Path, category: str) -> str:
+    html = path.read_text(encoding="utf-8", errors="ignore")
+    soup = BeautifulSoup(html, "html.parser")
+
+    for tag in soup(["script", "style", "noscript", "svg", "canvas", "form", "iframe", "frame", "embed", "object"]):
+        tag.decompose()
+    for tag in soup.select("header, footer, nav, aside, .fileBox, .btn, .paging, .breadcrumb"):
+        tag.decompose()
+
+    candidates = []
+    if category == "pknu_rule_bylaw":
+        selectors = [".subTableDtl > section", ".subTableDtl", "article", "body"]
+    else:
+        selectors = ["#conScroll", "#contentBody", ".lawcon", "article", "body"]
+
+    for selector in selectors:
+        selected = soup.select_one(selector)
+        if selected:
+            candidates.append(selected)
+
+    root = max(candidates or [soup], key=lambda tag: len(normalize_text(tag.get_text(" ", strip=True))))
+    lines = [normalize_text(line) for line in root.get_text("\n", strip=True).splitlines()]
+    lines = [line for line in lines if line]
+    return "\n".join(lines)
+
+
+def append_block(
+    blocks: list[dict[str, Any]],
+    seen: set[str],
+    block_type: str,
+    section: str,
+    text: object,
+    **extra: Any,
+) -> None:
+    value = normalize_text(text)
+    if not value:
+        return
+    key = re.sub(r"\s+", " ", value)
+    if key in seen:
+        return
+    seen.add(key)
+    blocks.append(
+        {
+            "type": block_type,
+            "section": section,
+            "text": value,
+            **extra,
+        }
+    )
+
+
+def iter_text_items(items: object) -> list[dict[str, Any]]:
+    if not isinstance(items, list):
+        return []
+    return [item for item in items if isinstance(item, dict) and normalize_text(item.get("text"))]
+
+
+def extract_rule_json_blocks(doc: dict[str, Any], html_root: Path) -> tuple[list[dict[str, Any]], bool]:
+    blocks: list[dict[str, Any]] = []
+    seen: set[str] = set()
+
+    append_block(blocks, seen, "title", "title", doc.get("title"))
+
+    metadata_lines = []
+    for label, key in (
+        ("category", "category"),
+        ("subcategory", "subcategory"),
+        ("type", "type"),
+        ("date", "date"),
+        ("source_id", "source_id"),
+        ("url", "url"),
+    ):
+        value = normalize_text(doc.get(key))
+        if value:
+            metadata_lines.append(f"{label}: {value}")
+    append_block(blocks, seen, "metadata", "metadata", "\n".join(metadata_lines))
+
+    html_text = doc.get("html_text") or doc.get("page_content")
+    append_block(blocks, seen, "body", "html_text", html_text)
+    append_block(blocks, seen, "body", "page_content", doc.get("page_content"))
+    append_block(blocks, seen, "body", "preview_content", doc.get("preview_content"))
+
+    for index, preview in enumerate(iter_text_items(doc.get("preview_texts")), start=1):
+        append_block(
+            blocks,
+            seen,
+            "body",
+            "preview_texts",
+            preview.get("text"),
+            source_url=preview.get("url", ""),
+            source_index=index,
+        )
+
+    file_previews = iter_text_items(doc.get("file_preview_texts"))
+    if not file_previews:
+        file_previews = iter_text_items(doc.get("attachment_texts"))
+    for index, preview in enumerate(file_previews, start=1):
+        append_block(
+            blocks,
+            seen,
+            "attachment_text",
+            "file_preview_texts",
+            preview.get("text"),
+            attachment_name=preview.get("name", ""),
+            attachment_url=preview.get("url", ""),
+            saved_path=preview.get("saved_path", ""),
+            source_index=index,
+        )
+
+    used_html_fallback = False
+    body_chars = sum(len(block["text"]) for block in blocks if block["section"] != "metadata")
+    if body_chars < 80:
+        html_path = html_path_for(doc, html_root)
+        if html_path:
+            html_text = extract_rule_html_text(html_path, normalize_text(doc.get("category")))
+            append_block(
+                blocks,
+                seen,
+                "body",
+                "html_fallback",
+                html_text,
+                html_path=rel_project_path(html_path),
+            )
+            used_html_fallback = bool(html_text)
+
+    return blocks, used_html_fallback
+
+
+def chunk_blocks(
+    blocks: list[dict[str, Any]],
+    chunk_size: int = DEFAULT_CHUNK_SIZE,
+    overlap: int = DEFAULT_CHUNK_OVERLAP,
+) -> list[dict[str, Any]]:
+    chunks: list[dict[str, Any]] = []
+    current: list[str] = []
+    current_sections: set[str] = set()
+    current_len = 0
+    chunk_id = 1
+
+    def flush() -> None:
+        nonlocal current, current_sections, current_len, chunk_id
+        if not current:
+            return
+        text = "\n".join(current).strip()
+        if text:
+            chunks.append(
+                {
+                    "chunk_id": chunk_id,
+                    "text": text,
+                    "num_lines": len(current),
+                    "num_chars": len(text),
+                    "sections": sorted(current_sections),
+                }
+            )
+            chunk_id += 1
+        if overlap > 0 and text:
+            tail = text[-overlap:].strip()
+            current = [tail] if tail else []
+            current_sections = {"overlap"} if tail else set()
+            current_len = len(tail)
+        else:
+            current = []
+            current_sections = set()
+            current_len = 0
+
+    for block in blocks:
+        text = normalize_text(block.get("text"))
+        if not text:
+            continue
+        section = normalize_text(block.get("section")) or "unknown"
+        add_len = len(text) + (1 if current else 0)
+        if current and current_len + add_len > chunk_size:
+            flush()
+        current.append(text)
+        current_sections.add(section)
+        current_len += add_len
+
+    if current:
+        text = "\n".join(current).strip()
+        if text:
+            chunks.append(
+                {
+                    "chunk_id": chunk_id,
+                    "text": text,
+                    "num_lines": len(current),
+                    "num_chars": len(text),
+                    "sections": sorted(current_sections),
+                }
+            )
+    return chunks
+
+
+def build_provenance(doc: dict[str, Any], input_file: Path) -> dict[str, Any]:
+    return {
+        "doc_title": doc.get("title", ""),
+        "doc_url": doc.get("url", ""),
+        "category": doc.get("category", ""),
+        "subcategory": doc.get("subcategory", ""),
+        "doc_type": doc.get("type", ""),
+        "date": doc.get("date", ""),
+        "source_id": doc.get("source_id", ""),
+        "source_site": doc.get("source_site", ""),
+        "crawled_at": doc.get("crawled_at", ""),
+        "source_page_url": doc.get("url", ""),
+        "source_json_path": rel_project_path(input_file),
+    }
+
+
+def write_preprocessed_result(
+    input_file: Path,
+    input_root: Path,
+    output_root: Path,
+    source_kind: str,
+    blocks: list[dict[str, Any]],
+    chunks: list[dict[str, Any]],
+    provenance: dict[str, Any],
+    used_html_fallback: bool = False,
+) -> str:
+    rel_in_input = rel_project_path(input_file, input_root)
+    source_slug = provenance.get("source_slug") or stable_slug(source_kind, rel_in_input)
+    result = {
+        "slug": stable_slug("rule", source_kind, source_slug),
+        "source_file": input_file.name,
+        "source_path": rel_project_path(input_file),
+        "source_relative_to_input": rel_in_input,
+        "source_ext": input_file.suffix.lower(),
+        "source_kind": source_kind,
+        "processed_at": datetime.now().isoformat(timespec="seconds"),
+        "num_blocks": len(blocks),
+        "total_chars": sum(len(block["text"]) for block in blocks),
+        "num_chunks": len(chunks),
+        "used_html_fallback": used_html_fallback,
+        "provenance": {
+            **provenance,
+            "source_kind": source_kind,
+        },
+        "blocks": blocks,
+        "chunks": chunks,
+    }
+
+    out_path = output_path_for(input_file, input_root, output_root / source_kind)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(result, ensure_ascii=False, indent=2), encoding="utf-8")
+    return out_path.as_posix()
+
+
+def preprocess_json_file(
+    input_file: Path,
+    input_root: Path,
+    output_root: Path,
+    html_root: Path,
+    chunk_size: int,
+    chunk_overlap: int,
+) -> tuple[bool, str]:
+    doc = json.loads(input_file.read_text(encoding="utf-8-sig"))
+    if not isinstance(doc, dict):
+        return False, "JSON root is not an object"
+
+    blocks, used_html_fallback = extract_rule_json_blocks(doc, html_root)
+    chunks = chunk_blocks(blocks, chunk_size=chunk_size, overlap=chunk_overlap)
+    if not chunks:
+        return False, "no chunks"
+
+    provenance = {
+        **build_provenance(doc, input_file),
+        "source_slug": normalize_text(doc.get("slug")) or stable_slug(rel_project_path(input_file, input_root)),
+    }
+    out_path = write_preprocessed_result(
+        input_file=input_file,
+        input_root=input_root,
+        output_root=output_root,
+        source_kind="json",
+        blocks=blocks,
+        chunks=chunks,
+        provenance=provenance,
+        used_html_fallback=used_html_fallback,
+    )
+    return True, out_path
+
+
+def preprocess_html_file(
+    input_file: Path,
+    input_root: Path,
+    output_root: Path,
+    docs_by_key: dict[str, dict[str, Any]],
+    chunk_size: int,
+    chunk_overlap: int,
+) -> tuple[bool, str]:
+    category = input_file.parent.name
+    slug = input_file.stem
+    text = extract_rule_html_text(input_file, category)
+    if not text:
+        return False, "no text"
+
+    blocks: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    provenance = docs_by_key.get(f"{category}/{slug}", {})
+    append_block(blocks, seen, "body", "html_text", text, html_path=rel_project_path(input_file))
+    chunks = chunk_blocks(blocks, chunk_size=chunk_size, overlap=chunk_overlap)
+    if not chunks:
+        return False, "no chunks"
+
+    out_path = write_preprocessed_result(
+        input_file=input_file,
+        input_root=input_root,
+        output_root=output_root,
+        source_kind="html",
+        blocks=blocks,
+        chunks=chunks,
+        provenance={
+            **provenance,
+            "source_slug": slug,
+            "category": provenance.get("category", category),
+            "source_html_path": rel_project_path(input_file),
+        },
+    )
+    return True, out_path
+
+
+def preprocess_attachment_file(
+    input_file: Path,
+    input_root: Path,
+    output_root: Path,
+    attachments_by_path: dict[str, dict[str, Any]],
+    chunk_size: int,
+    chunk_overlap: int,
+) -> tuple[bool, str]:
+    if input_file.stat().st_size == 0:
+        return False, "empty attachment file"
+
+    try:
+        from preprocessing import extract_blocks
+    except Exception as exc:
+        raise RuntimeError(f"preprocessing.extract_blocks import failed: {exc}") from exc
+
+    blocks = extract_blocks(input_file)
+    blocks = [block for block in blocks if normalize_text(block.get("text"))]
+    chunks = chunk_blocks(blocks, chunk_size=chunk_size, overlap=chunk_overlap)
+    if not chunks:
+        return False, "no chunks"
+
+    provenance = attachments_by_path.get(input_file.resolve().as_posix().lower(), {})
+    out_path = write_preprocessed_result(
+        input_file=input_file,
+        input_root=input_root,
+        output_root=output_root,
+        source_kind="file",
+        blocks=blocks,
+        chunks=chunks,
+        provenance={
+            **provenance,
+            "source_slug": stable_slug(rel_project_path(input_file, input_root)),
+            "source_attachment_path": rel_project_path(input_file),
+        },
+    )
+    return True, out_path
+
+
+def iter_json_files(input_root: Path) -> list[Path]:
+    if not input_root.exists():
+        return []
+    return sorted(path for path in input_root.rglob("*.json") if path.is_file())
+
+
+def iter_html_files(input_root: Path) -> list[Path]:
+    if not input_root.exists():
+        return []
+    return sorted(path for path in input_root.rglob("*.html") if path.is_file())
+
+
+def iter_attachment_files(input_root: Path) -> list[Path]:
+    if not input_root.exists():
+        return []
+    return sorted(
+        path
+        for path in input_root.rglob("*")
+        if path.is_file() and path.suffix.lower() in SUPPORTED_ATTACHMENT_EXTS
+    )
+
+
+def iter_failed_files_from_log(log_path: Path, project_root: Path = PROJECT_ROOT) -> list[Path]:
+    if not log_path.exists():
+        return []
+
+    failed: list[Path] = []
+    seen: set[Path] = set()
+    pattern = re.compile(r"\[FAIL:file\]\s+(.+?)\s+\(")
+    for line in log_path.read_text(encoding="utf-8", errors="replace").splitlines():
+        match = pattern.search(line)
+        if not match:
+            continue
+        path_text = match.group(1).strip()
+        path = Path(path_text)
+        if not path.is_absolute():
+            path = project_root / path
+        path = path.resolve()
+        if path in seen or not path.exists() or path.suffix.lower() not in SUPPORTED_ATTACHMENT_EXTS:
+            continue
+        seen.add(path)
+        failed.append(path)
+    return failed
+
+
+def run_batch(
+    json_root: Path,
+    html_root: Path,
+    files_root: Path,
+    output_root: Path,
+    source_scope: str,
+    failed_from_log: Path | None,
+    dry_run: bool,
+    chunk_size: int,
+    chunk_overlap: int,
+) -> None:
+    docs_by_key, attachments_by_path = load_rule_json_index(json_root)
+    tasks: list[tuple[str, Path, Path]] = []
+    if failed_from_log:
+        tasks.extend(("file", path, files_root) for path in iter_failed_files_from_log(failed_from_log))
+    else:
+        if source_scope in {"json", "all"}:
+            tasks.extend(("json", path, json_root) for path in iter_json_files(json_root))
+        if source_scope in {"html", "all"}:
+            tasks.extend(("html", path, html_root) for path in iter_html_files(html_root))
+        if source_scope in {"files", "all"}:
+            tasks.extend(("file", path, files_root) for path in iter_attachment_files(files_root))
+
+    if not tasks:
+        if failed_from_log:
+            log.info("No failed files found in %s", failed_from_log)
+        else:
+            log.info("No rule artifacts found for source_scope=%s", source_scope)
+        return
+
+    counts: dict[str, int] = {}
+    for source_kind, _, _ in tasks:
+        counts[source_kind] = counts.get(source_kind, 0) + 1
+    log.info("Found rule artifacts: %s", ", ".join(f"{key}={value}" for key, value in sorted(counts.items())))
+
+    ok = skipped = failed = 0
+    for source_kind, input_file, input_root in tasks:
+        rel = rel_project_path(input_file)
+        if dry_run:
+            log.info("[DRY-RUN:%s] %s", source_kind, rel)
+            continue
+        try:
+            if source_kind == "json":
+                log.info("[START:%s] %s", source_kind, rel)
+                saved, info = preprocess_json_file(
+                    input_file=input_file,
+                    input_root=input_root,
+                    output_root=output_root,
+                    html_root=html_root,
+                    chunk_size=chunk_size,
+                    chunk_overlap=chunk_overlap,
+                )
+            elif source_kind == "html":
+                log.info("[START:%s] %s", source_kind, rel)
+                saved, info = preprocess_html_file(
+                    input_file=input_file,
+                    input_root=input_root,
+                    output_root=output_root,
+                    docs_by_key=docs_by_key,
+                    chunk_size=chunk_size,
+                    chunk_overlap=chunk_overlap,
+                )
+            else:
+                log.info("[START:%s] %s", source_kind, rel)
+                saved, info = preprocess_attachment_file(
+                    input_file=input_file,
+                    input_root=input_root,
+                    output_root=output_root,
+                    attachments_by_path=attachments_by_path,
+                    chunk_size=chunk_size,
+                    chunk_overlap=chunk_overlap,
+                )
+            if saved:
+                ok += 1
+                log.info("[OK:%s] %s -> %s", source_kind, rel, info)
+            else:
+                skipped += 1
+                log.info("[SKIP:%s] %s (%s)", source_kind, rel, info)
+        except Exception as exc:
+            failed += 1
+            log.warning("[FAIL:%s] %s (%s)", source_kind, rel, exc)
+
+    if dry_run:
+        log.info("Dry run complete")
+    else:
+        log.info("Done: saved=%d, skipped=%d, failed=%d", ok, skipped, failed)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Preprocess crawled PKNU rule artifacts for RAG.")
+    parser.add_argument("--json-root", type=Path, default=DEFAULT_INPUT_ROOT)
+    parser.add_argument("--html-root", type=Path, default=DEFAULT_HTML_ROOT)
+    parser.add_argument("--files-root", type=Path, default=DEFAULT_FILES_ROOT)
+    parser.add_argument("--output-root", type=Path, default=DEFAULT_OUTPUT_ROOT)
+    parser.add_argument("--source-scope", choices=["json", "html", "files", "all"], default="all")
+    parser.add_argument(
+        "--failed-from-log",
+        type=Path,
+        default=None,
+        help="Reprocess only [FAIL:file] paths parsed from a preprocessing log.",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--chunk-size", type=int, default=DEFAULT_CHUNK_SIZE)
+    parser.add_argument("--chunk-overlap", type=int, default=DEFAULT_CHUNK_OVERLAP)
+    args = parser.parse_args()
+
+    configure_logging()
+    run_batch(
+        json_root=args.json_root.resolve(),
+        html_root=args.html_root.resolve(),
+        files_root=args.files_root.resolve(),
+        output_root=args.output_root.resolve(),
+        source_scope=args.source_scope,
+        failed_from_log=args.failed_from_log.resolve() if args.failed_from_log else None,
+        dry_run=args.dry_run,
+        chunk_size=args.chunk_size,
+        chunk_overlap=args.chunk_overlap,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/supabase/migrations/004_create_rule_rag_tables.sql
+++ b/supabase/migrations/004_create_rule_rag_tables.sql
@@ -1,0 +1,126 @@
+create extension if not exists vector with schema extensions;
+
+set search_path = public, extensions;
+
+create table if not exists public.rule_sources (
+    id text primary key,
+    source_slug text unique not null,
+    source_type text not null default 'unknown',
+    title text,
+    url text,
+    parent_url text,
+    file_path text,
+    file_ext text,
+    category text,
+    subcategory text,
+    status text not null default 'active',
+    metadata jsonb not null default '{}'::jsonb,
+    crawled_at timestamptz,
+    processed_at timestamptz,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now()
+);
+
+create table if not exists public.rule_chunks (
+    id text primary key,
+    source_id text not null references public.rule_sources(id) on delete cascade,
+    chunk_id integer not null,
+    chunk_index integer not null,
+    content text not null,
+    content_hash text,
+    token_count integer,
+    metadata jsonb not null default '{}'::jsonb,
+    embedding extensions.vector(384) not null,
+    embedding_model text not null default 'sentence-transformers:sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2',
+    embedding_dim integer not null default 384,
+    embedded_at timestamptz,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    unique (source_id, chunk_index)
+);
+
+create index if not exists rule_sources_source_slug_idx
+    on public.rule_sources (source_slug);
+
+create index if not exists rule_sources_status_idx
+    on public.rule_sources (status);
+
+create index if not exists rule_sources_metadata_gin_idx
+    on public.rule_sources using gin (metadata);
+
+create index if not exists rule_chunks_source_id_idx
+    on public.rule_chunks (source_id);
+
+create index if not exists rule_chunks_metadata_gin_idx
+    on public.rule_chunks using gin (metadata);
+
+create index if not exists rule_chunks_embedding_hnsw_idx
+    on public.rule_chunks
+    using hnsw (embedding vector_cosine_ops);
+
+create or replace function public.set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+    new.updated_at = now();
+    return new;
+end;
+$$;
+
+drop trigger if exists rule_sources_set_updated_at on public.rule_sources;
+create trigger rule_sources_set_updated_at
+before update on public.rule_sources
+for each row
+execute function public.set_updated_at();
+
+drop trigger if exists rule_chunks_set_updated_at on public.rule_chunks;
+create trigger rule_chunks_set_updated_at
+before update on public.rule_chunks
+for each row
+execute function public.set_updated_at();
+
+create or replace function public.match_rule_documents(
+    query_embedding extensions.vector(384),
+    match_count integer default 5,
+    min_similarity double precision default 0.0,
+    metadata_filter jsonb default '{}'::jsonb
+)
+returns table (
+    id text,
+    source_id text,
+    source_slug text,
+    source_type text,
+    title text,
+    url text,
+    parent_url text,
+    chunk_id integer,
+    chunk_index integer,
+    content text,
+    metadata jsonb,
+    similarity double precision
+)
+language sql
+stable
+as $$
+    select
+        c.id,
+        c.source_id,
+        s.source_slug,
+        s.source_type,
+        s.title,
+        s.url,
+        s.parent_url,
+        c.chunk_id,
+        c.chunk_index,
+        c.content,
+        s.metadata || c.metadata as metadata,
+        1.0 - (c.embedding <=> query_embedding) as similarity
+    from public.rule_chunks as c
+    join public.rule_sources as s on s.id = c.source_id
+    where s.status = 'active'
+      and (s.metadata || c.metadata) @> metadata_filter
+      and 1.0 - (c.embedding <=> query_embedding) >= min_similarity
+    order by c.embedding <=> query_embedding
+    limit greatest(match_count, 0);
+$$;


### PR DESCRIPTION
## 개요

부경대학교 규정집 (https://www.pknu.ac.kr/rule/main.do)에 대한 크롤러 및 전체 파이프라인을 구현했습니다.
또, `COMMANDS.md`에 각 코드들에 대한 설명 및 실행 옵션도 정리하였습니다.

## 규정집 크롤러(`rule/crawler.py`)
- 학칙/규정(`pknu_rule_law`)과 지침/세칙(`pknu_rule_bylaw`) 수집 지원
- JSON, HTML, 첨부파일을 `files/rule/output/` 아래에 저장
- 첨부파일 다운로드 및 텍스트 추출 지원

## 규정집 전처리 파이프라인
- JSON, HTML, 첨부파일을 각각 전처리
- 결과를 `files/rule/preprocessed/json`, `html`, `file`로 분리 저장
- 각 청크에 `source_kind` 및 provenance 메타데이터 보존
- 실패한 첨부파일만 로그 기반으로 재처리하는 옵션 추가

## Supabase 적재 및 검색 분리
- 규정집 전용 테이블 `rule_sources`, `rule_chunks` 추가
- 규정집 검색 함수 `match_rule_documents()` 추가

## 전반적인 파이프라인 개선 및 문서 업데이트
- `load_to_supabase.py`에 `--dataset` 옵션 추가
- `query_supabase.py`에 `--dataset` 옵션 추가
- CE와 규정집 데이터의 기본 입력/출력 경로를 옵션으로 선택 가능
- 스크립트 구조 정리하여 ce(컴퓨터·인공지능공학부), rules(규정집), RAG 공통 스크립트를 역할별 폴더로 이동
 ```bash
scripts/ce/
scripts/rule/
scripts/rag/
```
- 문서 업데이트
  - `docs/COMMANDS.md`에 실행 명령어 정리
  - `docs/DATA_STRUCTURE.md`에 규정집 데이터 구조 및 실행 흐름 추가

## 실행 흐름

규정집 데이터 파이프라인은 아래 순서로 실행합니다.

```powershell
python scripts/rule/crawler.py --laws --bylaws
python scripts/rule/preprocessing.py
python scripts/rag/vectorization.py --dataset rule --backend sentence-transformers
python scripts/rag/load_to_supabase.py --dataset rule