### PR TITLE
[Refactor] 메인 홈페이지 공지사항(notice) 및 슬기로운 학교생활(student_life) 전처리 과정 보완

### DIFF
--- a/scripts/rag/load_to_supabase.py
+++ b/scripts/rag/load_to_supabase.py
@@ -36,6 +36,16 @@ DATASET_TABLES = {
         "sources": "rag_sources",
         "chunks": "rag_chunks",
     },
+    "pknu_notice": {
+        "index": PROJECT_ROOT / "files" / "pknu_notice" / "vectorized" / "index.jsonl",
+        "sources": "pknu_notice_sources",
+        "chunks": "pknu_notice_chunks",
+    },
+    "pknu_student_life": {
+        "index": PROJECT_ROOT / "files" / "pknu_student_life" / "vectorized" / "index.jsonl",
+        "sources": "pknu_student_life_sources",
+        "chunks": "pknu_student_life_chunks",
+    },
     "rule": {
         "index": PROJECT_ROOT / "files" / "rule" / "vectorized" / "index.jsonl",
         "sources": "rule_sources",

--- a/scripts/rag/preprocessing.py
+++ b/scripts/rag/preprocessing.py
@@ -1,0 +1,132 @@
+"""Dataset-aware preprocessing entrypoint for RAG pipelines.
+
+This script centralizes RAG preprocessing execution across crawled datasets.
+The extraction implementation is currently shared with scripts.ce.preprocessing
+for compatibility, while dataset routing and source-scope orchestration live here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.ce.preprocessing import (  # noqa: E402
+    DEFAULT_CHUNK_OVERLAP,
+    DEFAULT_CHUNK_SIZE,
+    DEFAULT_OCR_DPI,
+    DEFAULT_OCR_LANGUAGE,
+    DEFAULT_PDF_OCR_MODE,
+    configure_logging,
+    run_batch,
+)
+
+
+DATASET_PATHS = {
+    "ce": {
+        "files_input_root": PROJECT_ROOT / "files" / "ce" / "output" / "files",
+        "files_output_root": PROJECT_ROOT / "files" / "ce" / "preprocessed" / "files",
+        "json_input_root": PROJECT_ROOT / "files" / "ce" / "output" / "json",
+        "json_output_root": PROJECT_ROOT / "files" / "ce" / "preprocessed" / "json",
+        "output_json_root": PROJECT_ROOT / "files" / "ce" / "output" / "json",
+    },
+    "pknu_notice": {
+        "files_input_root": PROJECT_ROOT / "files" / "pknu_notice" / "output" / "files",
+        "files_output_root": PROJECT_ROOT / "files" / "pknu_notice" / "preprocessed" / "files",
+        "json_input_root": PROJECT_ROOT / "files" / "pknu_notice" / "output" / "json",
+        "json_output_root": PROJECT_ROOT / "files" / "pknu_notice" / "preprocessed" / "json",
+        "output_json_root": PROJECT_ROOT / "files" / "pknu_notice" / "output" / "json",
+    },
+    "pknu_student_life": {
+        "files_input_root": PROJECT_ROOT / "files" / "pknu_student_life" / "output" / "files",
+        "files_output_root": PROJECT_ROOT / "files" / "pknu_student_life" / "preprocessed" / "files",
+        "json_input_root": PROJECT_ROOT / "files" / "pknu_student_life" / "output" / "json",
+        "json_output_root": PROJECT_ROOT / "files" / "pknu_student_life" / "preprocessed" / "json",
+        "output_json_root": PROJECT_ROOT / "files" / "pknu_student_life" / "output" / "json",
+    },
+}
+
+
+def build_specs(args: argparse.Namespace) -> list[tuple[Path, Path, Path, str]]:
+    dataset_paths = DATASET_PATHS[args.dataset]
+    has_path_override = bool(args.input_root or args.output_root or args.output_json_root)
+    if has_path_override:
+        return [
+            (
+                args.input_root or dataset_paths["files_input_root"],
+                args.output_root or dataset_paths["files_output_root"],
+                args.output_json_root or dataset_paths["output_json_root"],
+                args.layout or "by_ext",
+            )
+        ]
+
+    scopes = ["json", "files"] if args.source_scope == "all" else [args.source_scope]
+    specs = []
+    for scope in scopes:
+        specs.append(
+            (
+                dataset_paths[f"{scope}_input_root"],
+                dataset_paths[f"{scope}_output_root"],
+                dataset_paths["output_json_root"],
+                args.layout or ("flat" if scope == "json" else "by_ext"),
+            )
+        )
+    return specs
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Preprocess crawled dataset outputs into RAG chunk JSON files."
+    )
+    parser.add_argument("--dataset", choices=sorted(DATASET_PATHS), default="ce")
+    parser.add_argument(
+        "--source-scope",
+        choices=["files", "json", "all"],
+        default="all",
+        help="Dataset preset source to preprocess.",
+    )
+    parser.add_argument("--input-root", type=Path, default=None)
+    parser.add_argument("--output-root", type=Path, default=None)
+    parser.add_argument("--output-json-root", type=Path, default=None)
+    parser.add_argument("--failed-from-log", type=Path, default=None)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--chunk-size", type=int, default=DEFAULT_CHUNK_SIZE)
+    parser.add_argument("--chunk-overlap", type=int, default=DEFAULT_CHUNK_OVERLAP)
+    parser.add_argument(
+        "--pdf-ocr",
+        choices=["auto", "never", "always"],
+        default=DEFAULT_PDF_OCR_MODE,
+    )
+    parser.add_argument("--ocr-language", default=DEFAULT_OCR_LANGUAGE)
+    parser.add_argument("--ocr-dpi", type=int, default=DEFAULT_OCR_DPI)
+    parser.add_argument("--layout", choices=["by_ext", "flat"], default=None)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    configure_logging()
+
+    for input_root, output_root, output_json_root, layout in build_specs(args):
+        run_batch(
+            input_root=input_root,
+            output_root=output_root,
+            output_json_root=output_json_root,
+            project_root=PROJECT_ROOT,
+            failed_from_log=args.failed_from_log.resolve() if args.failed_from_log else None,
+            dry_run=args.dry_run,
+            chunk_size=args.chunk_size,
+            chunk_overlap=args.chunk_overlap,
+            pdf_ocr_mode=args.pdf_ocr,
+            ocr_language=args.ocr_language,
+            ocr_dpi=args.ocr_dpi,
+            layout=layout,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rag/query_supabase.py
+++ b/scripts/rag/query_supabase.py
@@ -25,12 +25,22 @@ DEFAULT_MODEL = "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
 EXPECTED_DIMENSIONS = 384
 DATASET_MATCH_FUNCTIONS = {
     "ce": "match_rag_documents",
+    "pknu_notice": "match_pknu_notice_documents",
+    "pknu_student_life": "match_pknu_student_life_documents",
     "rule": "match_rule_documents",
 }
 DATASET_TABLES = {
     "ce": {
         "sources": "rag_sources",
         "chunks": "rag_chunks",
+    },
+    "pknu_notice": {
+        "sources": "pknu_notice_sources",
+        "chunks": "pknu_notice_chunks",
+    },
+    "pknu_student_life": {
+        "sources": "pknu_student_life_sources",
+        "chunks": "pknu_student_life_chunks",
     },
     "rule": {
         "sources": "rule_sources",

--- a/scripts/rag/vectorization.py
+++ b/scripts/rag/vectorization.py
@@ -57,6 +57,14 @@ DATASET_PATHS = {
         "input_root": PROJECT_ROOT / "files" / "ce" / "preprocessed",
         "output_root": PROJECT_ROOT / "files" / "ce" / "vectorized",
     },
+    "pknu_notice": {
+        "input_root": PROJECT_ROOT / "files" / "pknu_notice" / "preprocessed",
+        "output_root": PROJECT_ROOT / "files" / "pknu_notice" / "vectorized",
+    },
+    "pknu_student_life": {
+        "input_root": PROJECT_ROOT / "files" / "pknu_student_life" / "preprocessed",
+        "output_root": PROJECT_ROOT / "files" / "pknu_student_life" / "vectorized",
+    },
     "rule": {
         "input_root": PROJECT_ROOT / "files" / "rule" / "preprocessed",
         "output_root": PROJECT_ROOT / "files" / "rule" / "vectorized",
@@ -455,6 +463,7 @@ def main() -> None:
         help=(
             "Dataset path preset to vectorize. "
             "Use ce for files/ce/preprocessed -> files/ce/vectorized, "
+            "pknu_notice for files/pknu_notice/preprocessed -> files/pknu_notice/vectorized, "
             "or rule for files/rule/preprocessed -> files/rule/vectorized."
         ),
     )

--- a/supabase/migrations/006_create_pknu_notice_rag_tables.sql
+++ b/supabase/migrations/006_create_pknu_notice_rag_tables.sql
@@ -1,0 +1,126 @@
+create extension if not exists vector with schema extensions;
+
+set search_path = public, extensions;
+
+create table if not exists public.pknu_notice_sources (
+    id text primary key,
+    source_slug text unique not null,
+    source_type text not null default 'unknown',
+    title text,
+    url text,
+    parent_url text,
+    file_path text,
+    file_ext text,
+    category text,
+    subcategory text,
+    status text not null default 'active',
+    metadata jsonb not null default '{}'::jsonb,
+    crawled_at timestamptz,
+    processed_at timestamptz,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now()
+);
+
+create table if not exists public.pknu_notice_chunks (
+    id text primary key,
+    source_id text not null references public.pknu_notice_sources(id) on delete cascade,
+    chunk_id integer not null,
+    chunk_index integer not null,
+    content text not null,
+    content_hash text,
+    token_count integer,
+    metadata jsonb not null default '{}'::jsonb,
+    embedding extensions.vector(384) not null,
+    embedding_model text not null default 'sentence-transformers:sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2',
+    embedding_dim integer not null default 384,
+    embedded_at timestamptz,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    unique (source_id, chunk_index)
+);
+
+create index if not exists pknu_notice_sources_source_slug_idx
+    on public.pknu_notice_sources (source_slug);
+
+create index if not exists pknu_notice_sources_status_idx
+    on public.pknu_notice_sources (status);
+
+create index if not exists pknu_notice_sources_metadata_gin_idx
+    on public.pknu_notice_sources using gin (metadata);
+
+create index if not exists pknu_notice_chunks_source_id_idx
+    on public.pknu_notice_chunks (source_id);
+
+create index if not exists pknu_notice_chunks_metadata_gin_idx
+    on public.pknu_notice_chunks using gin (metadata);
+
+create index if not exists pknu_notice_chunks_embedding_hnsw_idx
+    on public.pknu_notice_chunks
+    using hnsw (embedding vector_cosine_ops);
+
+create or replace function public.set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+    new.updated_at = now();
+    return new;
+end;
+$$;
+
+drop trigger if exists pknu_notice_sources_set_updated_at on public.pknu_notice_sources;
+create trigger pknu_notice_sources_set_updated_at
+before update on public.pknu_notice_sources
+for each row
+execute function public.set_updated_at();
+
+drop trigger if exists pknu_notice_chunks_set_updated_at on public.pknu_notice_chunks;
+create trigger pknu_notice_chunks_set_updated_at
+before update on public.pknu_notice_chunks
+for each row
+execute function public.set_updated_at();
+
+create or replace function public.match_pknu_notice_documents(
+    query_embedding extensions.vector(384),
+    match_count integer default 5,
+    min_similarity double precision default 0.0,
+    metadata_filter jsonb default '{}'::jsonb
+)
+returns table (
+    id text,
+    source_id text,
+    source_slug text,
+    source_type text,
+    title text,
+    url text,
+    parent_url text,
+    chunk_id integer,
+    chunk_index integer,
+    content text,
+    metadata jsonb,
+    similarity double precision
+)
+language sql
+stable
+as $$
+    select
+        c.id,
+        c.source_id,
+        s.source_slug,
+        s.source_type,
+        s.title,
+        s.url,
+        s.parent_url,
+        c.chunk_id,
+        c.chunk_index,
+        c.content,
+        s.metadata || c.metadata as metadata,
+        1.0 - (c.embedding <=> query_embedding) as similarity
+    from public.pknu_notice_chunks as c
+    join public.pknu_notice_sources as s on s.id = c.source_id
+    where s.status = 'active'
+      and (s.metadata || c.metadata) @> metadata_filter
+      and 1.0 - (c.embedding <=> query_embedding) >= min_similarity
+    order by c.embedding <=> query_embedding
+    limit greatest(match_count, 0);
+$$;

--- a/supabase/migrations/007_create_pknu_student_life_rag_tables.sql
+++ b/supabase/migrations/007_create_pknu_student_life_rag_tables.sql
@@ -1,0 +1,126 @@
+create extension if not exists vector with schema extensions;
+
+set search_path = public, extensions;
+
+create table if not exists public.pknu_student_life_sources (
+    id text primary key,
+    source_slug text unique not null,
+    source_type text not null default 'unknown',
+    title text,
+    url text,
+    parent_url text,
+    file_path text,
+    file_ext text,
+    category text,
+    subcategory text,
+    status text not null default 'active',
+    metadata jsonb not null default '{}'::jsonb,
+    crawled_at timestamptz,
+    processed_at timestamptz,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now()
+);
+
+create table if not exists public.pknu_student_life_chunks (
+    id text primary key,
+    source_id text not null references public.pknu_student_life_sources(id) on delete cascade,
+    chunk_id integer not null,
+    chunk_index integer not null,
+    content text not null,
+    content_hash text,
+    token_count integer,
+    metadata jsonb not null default '{}'::jsonb,
+    embedding extensions.vector(384) not null,
+    embedding_model text not null default 'sentence-transformers:sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2',
+    embedding_dim integer not null default 384,
+    embedded_at timestamptz,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    unique (source_id, chunk_index)
+);
+
+create index if not exists pknu_student_life_sources_source_slug_idx
+    on public.pknu_student_life_sources (source_slug);
+
+create index if not exists pknu_student_life_sources_status_idx
+    on public.pknu_student_life_sources (status);
+
+create index if not exists pknu_student_life_sources_metadata_gin_idx
+    on public.pknu_student_life_sources using gin (metadata);
+
+create index if not exists pknu_student_life_chunks_source_id_idx
+    on public.pknu_student_life_chunks (source_id);
+
+create index if not exists pknu_student_life_chunks_metadata_gin_idx
+    on public.pknu_student_life_chunks using gin (metadata);
+
+create index if not exists pknu_student_life_chunks_embedding_hnsw_idx
+    on public.pknu_student_life_chunks
+    using hnsw (embedding vector_cosine_ops);
+
+create or replace function public.set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+    new.updated_at = now();
+    return new;
+end;
+$$;
+
+drop trigger if exists pknu_student_life_sources_set_updated_at on public.pknu_student_life_sources;
+create trigger pknu_student_life_sources_set_updated_at
+before update on public.pknu_student_life_sources
+for each row
+execute function public.set_updated_at();
+
+drop trigger if exists pknu_student_life_chunks_set_updated_at on public.pknu_student_life_chunks;
+create trigger pknu_student_life_chunks_set_updated_at
+before update on public.pknu_student_life_chunks
+for each row
+execute function public.set_updated_at();
+
+create or replace function public.match_pknu_student_life_documents(
+    query_embedding extensions.vector(384),
+    match_count integer default 5,
+    min_similarity double precision default 0.0,
+    metadata_filter jsonb default '{}'::jsonb
+)
+returns table (
+    id text,
+    source_id text,
+    source_slug text,
+    source_type text,
+    title text,
+    url text,
+    parent_url text,
+    chunk_id integer,
+    chunk_index integer,
+    content text,
+    metadata jsonb,
+    similarity double precision
+)
+language sql
+stable
+as $$
+    select
+        c.id,
+        c.source_id,
+        s.source_slug,
+        s.source_type,
+        s.title,
+        s.url,
+        s.parent_url,
+        c.chunk_id,
+        c.chunk_index,
+        c.content,
+        s.metadata || c.metadata as metadata,
+        1.0 - (c.embedding <=> query_embedding) as similarity
+    from public.pknu_student_life_chunks as c
+    join public.pknu_student_life_sources as s on s.id = c.source_id
+    where s.status = 'active'
+      and (s.metadata || c.metadata) @> metadata_filter
+      and 1.0 - (c.embedding <=> query_embedding) >= min_similarity
+    order by c.embedding <=> query_embedding
+    limit greatest(match_count, 0);
+$$;


### PR DESCRIPTION
## 개요

- 메인 홈페이지 문서 관련 전처리 과정을 보완하였습니다.

## 설명

#### `/ce`에 있는 `preprocessing.py`를 재활용하는 방식에서 `/rag`에 추가된 `preprocessing.py`에 옵션을 부여하는 방식으로 변경
  - 이전에 실행한 전처리 파일들에 영향이 거의 없어 재실행 필요는 없음
 
#### 메인 홈페이지 공지사항(`notice`)와 슬기로운 학교생활(`student_life`) 문서에 대한 테이블 생성 SQL문 작성
  - `006_create_pknu_notice_rag_tables.sql` / `007_create_pknu_student_life_rag_tables.sql`
  - Supabase의 **'SQL Editor'**에 **'shared query'**로 저장되어 있음 