### PR TITLE
[FEAT] 거대 chunk 분할 + 질문 검색 정규화 모듈 (pknu 데이터 품질 개선)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ nav_output.txt
 
 # 크롤러 임시 파일
 .crawl_start.txt
+
+CLAUDE.md
+backups/

--- a/backend/app/query_transform.py
+++ b/backend/app/query_transform.py
@@ -1,0 +1,228 @@
+"""학생 질문(자연어)을 검색 친화 형태로 정규화하는 규칙 기반 변환 모듈.
+
+파이프라인: normalize → strip_fillers → expand_abbreviations → expand_synonyms → normalize.
+멱등성 보장 — transform_query(transform_query(x)) == transform_query(x).
+FastAPI / DB 의존성 없음 — backend 와 scripts 양쪽에서 import 가능.
+
+이 모듈의 책임 범위
+--------------------
+- 노이즈 토큰(인사·공손·1인칭 등 filler) 회피
+- 학생 통용 약어를 부경대 공식 명칭으로 정규화 (토큰 수 증가 없는 대체)
+- 좁고 명확한 동의어 보강 (실측 입증된 항목만)
+
+이 모듈이 풀지 않는 문제
+------------------------
+- False confidence (토큰을 추가하면 유사도는 올라가지만 정확도와 무관해지는 현상):
+  본질적 해결은 retrieval/rerank 단계 (BM25 hybrid, cross-encoder rerank, MMR,
+  per-query 동적 threshold 등). 본 모듈은 "광범위 토큰을 추가하지 않는다"는
+  소극적 원칙으로만 부분 기여.
+- 데이터셋 라우팅 (out-of-scope):
+  예) "외국인 한국어 강좌 신청" — 단발 공지가 아니라 국제교류부 상시 안내 영역
+      "수업 빠지면 어떻게" — 학칙(rule 데이터셋) 영역
+  이런 질문은 query 가공과 무관하게 공지사항 데이터셋에 매칭 가능한 chunk가
+  본질적으로 없음. 의도 분류 또는 멀티 데이터셋 검색이 별도로 필요하며,
+  본 모듈의 효과 측정에서는 제외해야 함.
+
+한국어 단어 경계는 \\b 가 작동하지 않아 lookaround 정규식으로 처리한다.
+조사 결합(예: "복전이", "복전을")은 1차에서는 매칭하지 않는다 — 의도적 보수.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+FILLER_PHRASES: tuple[str, ...] = (
+    # 인사·공손 종결
+    "안녕하세요", "안녕하십니까", "안녕", "감사합니다", "감사해요",
+    # 공손체 / 부탁 어구
+    "알 수 있을까요", "알려 주세요", "알려주세요", "알려줄래요", "알려줄 수",
+    "자세하게", "자세히", "자세한", "구체적으로",
+    # ~하려고 / ~싶다
+    "하려고 하는데", "하려는데", "하고 싶은데", "하고 싶어요",
+    # ~어떻게 종결
+    "어떻게 해야 되나요", "어떻게 해야 하나요", "어떻게 되나요", "어떻게 하나요",
+    # 1인칭 / 지칭
+    "친구 한 명이", "친구 중에", "친구가",
+    "제가", "저는", "저희", "내가", "나는",
+    # 분리 어구
+    "혹시", "좀",
+)
+
+# 약어 → 정식 명칭. 키가 사라지고 정식 명칭으로 대체된다 (멱등 보장 위해
+# 값 안에 키가 단어 경계로 다시 매칭될 수 있는 항목은 SYNONYMS로 옮긴다).
+# 런타임에 키 길이 내림차순 정렬 후 적용해서 "대연캠"이 "대연"보다 우선 매칭되도록 보장.
+ABBREVIATIONS: dict[str, str] = {
+    "복전": "복수전공",
+    "부전": "부전공",
+    "교직": "교직과정",
+    "근장": "근로장학생",
+    "현장실습": "현장실습학기제",
+    "교환학": "교환학생",
+    "졸유": "졸업유예",
+    "조졸": "조기졸업",
+    "국장": "국가장학금",
+    "대연캠": "대연캠퍼스",
+    "용당캠": "용당캠퍼스",
+    "대연": "대연캠퍼스",
+    "용당": "용당캠퍼스",
+}
+
+# 키가 텍스트에 나타나면 값 리스트 단어를 부족분만 append. 원본 단어는 보존.
+# 동의어가 추가될 뿐이라 한 번 적용 후엔 모든 값이 텍스트에 존재 → 멱등.
+#
+# 분류 (baseline 측정 기반):
+#   유지: Q7에서 효과 입증된 교환학생 동의어 군.
+#   보류: 좁고 명확하나 미측정 — 데이터 확보 후 재평가.
+#   삭제: 광범위 토큰("모집/신청/프로그램/변경/대출/수업/강좌/유학생") 추가로
+#         Q2 회귀·Q3 false confidence 일으킨 항목 9개. 9개 항목 제거됨
+#         (수업 빠, 비교과, 전과, 학자금, 장학금 신청, 복학, 휴학, 한국어, 외국인).
+SYNONYMS: dict[str, tuple[str, ...]] = {
+    # 유지 — Q7 실측 입증
+    "교환학생":   ("교환수학", "해외수학"),
+    "교환":      ("교환학생",),
+    # 보류: 미측정, 데이터 확보 후 재평가
+    "결석":      ("결강", "출결"),
+    "출석":      ("출결",),
+    "결강":      ("결석",),
+    "출결":      ("결석",),
+    "휴강":      ("강의 휴업",),
+    "재이수":    ("재수강",),
+}
+
+_HANGUL_OR_ALNUM = "가-힣A-Za-z0-9"
+_MULTISPACE_RE = re.compile(r"\s+")
+_TRAILING_PUNCT_RE = re.compile(r"[?!.\s]+$")
+
+
+def _normalize(text: str) -> str:
+    if not text:
+        return ""
+    text = text.replace(" ", " ").strip()
+    text = _MULTISPACE_RE.sub(" ", text)
+    text = _TRAILING_PUNCT_RE.sub("", text)
+    return text
+
+
+def _strip_fillers(
+    text: str, *, fillers: Iterable[str] = FILLER_PHRASES
+) -> tuple[str, list[str]]:
+    removed: list[str] = []
+    # 긴 어구 먼저 — 짧은 어구의 부분 일치를 막는다.
+    for phrase in sorted(fillers, key=len, reverse=True):
+        if phrase and phrase in text:
+            text = text.replace(phrase, " ")
+            removed.append(phrase)
+    return _normalize(text), removed
+
+
+def _expand_abbreviations(
+    text: str, *, table: dict[str, str] = ABBREVIATIONS
+) -> tuple[str, list[tuple[str, str]]]:
+    applied: list[tuple[str, str]] = []
+    # 긴 약어 먼저 — "대연캠"이 "대연"보다 우선 매칭.
+    for abbr in sorted(table, key=len, reverse=True):
+        full = table[abbr]
+        pattern = re.compile(
+            f"(?<![{_HANGUL_OR_ALNUM}]){re.escape(abbr)}(?![{_HANGUL_OR_ALNUM}])"
+        )
+        new_text, n = pattern.subn(full, text)
+        if n:
+            text = new_text
+            applied.append((abbr, full))
+    return _normalize(text), applied
+
+
+def _expand_synonyms(
+    text: str, *, table: dict[str, tuple[str, ...]] = SYNONYMS
+) -> tuple[str, list[tuple[str, tuple[str, ...]]]]:
+    applied: list[tuple[str, tuple[str, ...]]] = []
+    for key, extras in table.items():
+        if key in text:
+            missing = tuple(e for e in extras if e not in text)
+            if missing:
+                text = f"{text} {' '.join(missing)}"
+                applied.append((key, missing))
+    return _normalize(text), applied
+
+
+def transform_query(question: str) -> str:
+    """학생 질문 → 검색 친화 form. 멱등."""
+    text = _normalize(question)
+    text, _ = _strip_fillers(text)
+    text, _ = _expand_abbreviations(text)
+    text, _ = _expand_synonyms(text)
+    return _normalize(text)
+
+
+def transform_query_debug(question: str) -> dict:
+    """transform_query와 동일 결과 + 각 단계 흔적을 반환 (튜닝 디버깅용)."""
+    original = question
+    after_norm = _normalize(question)
+    after_strip, removed = _strip_fillers(after_norm)
+    after_abbr, abbrs = _expand_abbreviations(after_strip)
+    after_syn, syns = _expand_synonyms(after_abbr)
+    final = _normalize(after_syn)
+    return {
+        "original": original,
+        "after_normalize": after_norm,
+        "after_strip_filler": after_strip,
+        "after_expand_abbr": after_abbr,
+        "after_expand_syn": after_syn,
+        "final": final,
+        "removed_fillers": removed,
+        "applied_abbrs": abbrs,
+        "applied_synonyms": syns,
+    }
+
+
+def _run_self_tests() -> int:
+    cases: list[tuple[str, str]] = [
+        # 회귀 방지 — 짧은 키워드는 그대로
+        ("수강신청 기간", "수강신청 기간"),
+        ("장학금", "장학금"),
+        # filler 제거 (휴학 SYNONYMS 삭제 후 동의어 추가 없음)
+        ("안녕하세요 휴학 절차 알려주세요", "휴학 절차"),
+        # 약어 확장 + filler 제거
+        ("복전 신청 어떻게 하나요", "복수전공 신청"),
+        # 합성어 안의 약어는 매칭하지 않음 (단어 경계)
+        ("교직이수 안내", "교직이수 안내"),
+        # 띄어쓰기 있으면 매칭
+        ("교직 이수 안내", "교직과정 이수 안내"),
+        # 동의어 보강 (원본 보존 + extras append)
+        ("교환학생 가는 방법", "교환학생 가는 방법 교환수학 해외수학"),
+        # 캠퍼스 약어 — 긴 거 먼저 (대연캠 → 대연캠퍼스, 대연캠퍼스캠퍼스 X)
+        ("대연캠 위치", "대연캠퍼스 위치"),
+        ("용당캠 셔틀", "용당캠퍼스 셔틀"),
+        # 짧은 캠퍼스 약어 — 단어 경계 있을 때만
+        ("대연 본관", "대연캠퍼스 본관"),
+        # 조사 결합은 1차에서 매칭 안 함 (의도적)
+        ("대연에서 출발", "대연에서 출발"),
+        # 종합: 1인칭 + 동의어 + 종결 어구
+        ("저는 결석 처리 어떻게 되나요", "결석 처리 결강 출결"),
+        # 복학 — 동의어 추가 없음 (회귀 방지 위해 SYNONYMS 삭제)
+        ("복학 신청 기간", "복학 신청 기간"),
+    ]
+    fail = 0
+    for inp, expected in cases:
+        got = transform_query(inp)
+        ok = got == expected
+        status = "OK" if ok else "FAIL"
+        print(f"  [{status}] {inp!r} -> {got!r}" + ("" if ok else f"  (expected {expected!r})"))
+        if not ok:
+            fail += 1
+    # 멱등성: 한 번 더 통과시켜도 동일해야 함
+    for inp, _ in cases:
+        once = transform_query(inp)
+        twice = transform_query(once)
+        if once != twice:
+            print(f"  [FAIL idempotency] {inp!r}: {once!r} -> {twice!r}")
+            fail += 1
+    print(f"\n{len(cases)} cases, {fail} failure(s)")
+    return 1 if fail else 0
+
+
+if __name__ == "__main__":
+    import sys
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.exit(_run_self_tests())

--- a/scripts/ce/preprocessing.py
+++ b/scripts/ce/preprocessing.py
@@ -1019,15 +1019,61 @@ def build_metadata_fallback_blocks(
     return [{"type": "metadata_fallback", "style": "Metadata", "text": "\n".join(lines)}]
 
 
+_OVERSIZED_BOUNDARY_RE = re.compile(r"[\n。．\.!?！？]")
+
+
+def _split_oversized_text(text: str, max_size: int, overlap: int) -> list[str]:
+    """단일 텍스트가 max_size를 넘으면 문장/공백 경계 기준 슬라이딩 분할.
+
+    경계를 못 찾으면 문자 단위로 자른다. overlap은 인접 조각이 겹치도록 유지한다.
+    """
+    if len(text) <= max_size:
+        return [text]
+    if max_size <= overlap or max_size <= 0:
+        step = max(max_size, 1)
+        return [text[i : i + step] for i in range(0, len(text), step)]
+
+    pieces: list[str] = []
+    start = 0
+    while start < len(text):
+        end = min(start + max_size, len(text))
+        if end < len(text):
+            # 윈도우 뒤쪽 20% 안에서 문장/문단 경계를 찾아 그 지점에서 자른다.
+            search_from = start + int(max_size * 0.8)
+            tail = text[search_from:end]
+            matches = list(_OVERSIZED_BOUNDARY_RE.finditer(tail))
+            if matches:
+                end = search_from + matches[-1].end()
+            else:
+                ws_pos = text.rfind(" ", search_from, end)
+                if ws_pos > search_from:
+                    end = ws_pos + 1
+        pieces.append(text[start:end])
+        if end >= len(text):
+            break
+        start = max(start + 1, end - overlap)
+    return pieces
+
+
 def chunk_blocks(
     blocks: list[dict],
     chunk_size: int = DEFAULT_CHUNK_SIZE,
     overlap: int = DEFAULT_CHUNK_OVERLAP,
 ) -> list[dict]:
-    texts = [normalize_text(b.get("text", "")) for b in blocks]
-    texts = [t for t in texts if t]
-    if not texts:
+    raw_texts = [normalize_text(b.get("text", "")) for b in blocks]
+    raw_texts = [t for t in raw_texts if t]
+    if not raw_texts:
         return []
+
+    # paragraph 단위 청킹이라, 단일 block의 text가 chunk_size를 넘으면
+    # 아래 누적 루프의 size 체크가 동작하지 않아 거대 chunk가 생긴다.
+    # 미리 펼쳐서 모든 텍스트가 chunk_size 이하가 되도록 한다.
+    texts: list[str] = []
+    for t in raw_texts:
+        if len(t) <= chunk_size:
+            texts.append(t)
+        else:
+            texts.extend(_split_oversized_text(t, chunk_size, overlap))
 
     chunks: list[dict] = []
     current: list[str] = []

--- a/scripts/rag/split_oversized_chunks.py
+++ b/scripts/rag/split_oversized_chunks.py
@@ -1,0 +1,420 @@
+"""거대 chunk를 외과적으로 분할/재임베딩/교체하는 1회용 스크립트.
+
+DB에서 LENGTH(content) >= --threshold 인 chunk를 찾아 scripts/ce/preprocessing.chunk_blocks
+로 다시 자른 뒤 재임베딩, 원본 chunk를 트랜잭션 안에서 DELETE하고 새 sub-chunk를
+INSERT 한다. sources 테이블은 건드리지 않는다.
+
+기본은 dry-run. 실제 변경하려면 --apply 명시.
+실제 변경 직전에 영향 받는 chunk row 전체를 backups/split_oversized/<dataset>_<ts>.json
+으로 dump 한다 (--no-backup 으로만 끌 수 있음).
+
+사용:
+    # dry-run (변경 없음, 무엇을 어떻게 자를지 콘솔에 출력)
+    python scripts/rag/split_oversized_chunks.py --dataset pknu_notice
+    python scripts/rag/split_oversized_chunks.py --dataset pknu_student_life
+
+    # 실제 적용 (백업 자동, threshold 5000 기본)
+    python scripts/rag/split_oversized_chunks.py --dataset pknu_notice --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import psycopg
+from dotenv import load_dotenv
+from psycopg import sql
+from psycopg.rows import dict_row
+from psycopg.types.json import Jsonb
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.ce.preprocessing import (  # noqa: E402
+    DEFAULT_CHUNK_OVERLAP,
+    DEFAULT_CHUNK_SIZE,
+    chunk_blocks,
+)
+from scripts.rag.vectorization import stable_id  # noqa: E402
+
+LOG_DIR = PROJECT_ROOT / "logs"
+LOG_FILE = LOG_DIR / "split_oversized_chunks.log"
+
+DATASET_TABLES = {
+    "pknu_notice": {"sources": "pknu_notice_sources", "chunks": "pknu_notice_chunks"},
+    "pknu_student_life": {"sources": "pknu_student_life_sources", "chunks": "pknu_student_life_chunks"},
+}
+
+DEFAULT_THRESHOLD = 5000
+DEFAULT_BACKUP_DIR = PROJECT_ROOT / "backups" / "split_oversized"
+EXPECTED_EMBEDDING_DIM = 384
+DEFAULT_EMBEDDING_MODEL = "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
+
+log = logging.getLogger("split_oversized_chunks")
+
+
+def configure_logging() -> None:
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        handlers=[
+            logging.StreamHandler(sys.stdout),
+            logging.FileHandler(LOG_FILE, encoding="utf-8"),
+        ],
+    )
+
+
+def connect() -> psycopg.Connection:
+    load_dotenv(PROJECT_ROOT / "backend" / ".env")
+    dsn = os.getenv("DATABASE_URL") or os.getenv("SUPABASE_DB_URL")
+    if not dsn:
+        raise RuntimeError("DATABASE_URL not set in backend/.env")
+    return psycopg.connect(dsn, connect_timeout=15, autocommit=False)
+
+
+def vector_literal(values: list[float]) -> str:
+    return "[" + ",".join(str(float(v)) for v in values) + "]"
+
+
+def fetch_oversized(
+    conn: psycopg.Connection, chunks_table: str, sources_table: str, threshold: int
+) -> list[dict[str, Any]]:
+    query = sql.SQL(
+        """
+        SELECT
+            c.id,
+            c.source_id,
+            c.chunk_id,
+            c.chunk_index,
+            c.content,
+            c.content_hash,
+            c.token_count,
+            c.metadata,
+            c.embedding_model,
+            c.embedding_dim,
+            s.source_slug,
+            s.title AS source_title,
+            s.url AS source_url,
+            s.source_type
+        FROM {chunks} c
+        JOIN {sources} s ON s.id = c.source_id
+        WHERE LENGTH(c.content) >= %s
+        ORDER BY LENGTH(c.content) DESC
+        """
+    ).format(
+        chunks=sql.Identifier("public", chunks_table),
+        sources=sql.Identifier("public", sources_table),
+    )
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(query, (threshold,))
+        return list(cur.fetchall())
+
+
+def max_chunk_index_per_source(
+    conn: psycopg.Connection, chunks_table: str, source_ids: list[str]
+) -> dict[str, int]:
+    if not source_ids:
+        return {}
+    query = sql.SQL(
+        "SELECT source_id, MAX(chunk_index) AS mx FROM {chunks} WHERE source_id = ANY(%s) GROUP BY source_id"
+    ).format(chunks=sql.Identifier("public", chunks_table))
+    with conn.cursor() as cur:
+        cur.execute(query, (source_ids,))
+        return {row[0]: int(row[1]) for row in cur.fetchall()}
+
+
+def split_one(
+    row: dict[str, Any], chunk_size: int, overlap: int
+) -> list[dict[str, Any]]:
+    """원본 chunk row를 받아 chunk_blocks로 다시 잘라 sub-chunk dict 리스트를 만든다.
+
+    임베딩은 아직 채우지 않는다 (dry-run에서는 임베딩 계산 자체를 건너뛴다).
+    """
+    blocks = [{"text": row["content"]}]
+    sub = chunk_blocks(blocks, chunk_size=chunk_size, overlap=overlap)
+    return sub
+
+
+class EmbedderLazy:
+    """필요할 때만 sentence-transformers 모델을 로드한다 (dry-run에서는 안 로드)."""
+
+    def __init__(self, model_name: str) -> None:
+        self._model_name = model_name
+        self._model = None
+
+    def encode(self, texts: list[str]) -> list[list[float]]:
+        if self._model is None:
+            from sentence_transformers import SentenceTransformer  # type: ignore
+
+            log.info("Loading embedder %s ...", self._model_name)
+            self._model = SentenceTransformer(self._model_name)
+        vectors = self._model.encode(
+            texts,
+            normalize_embeddings=True,
+            show_progress_bar=False,
+        )
+        return [[round(float(v), 8) for v in row] for row in vectors]
+
+
+def derive_embedding_model(rows: list[dict[str, Any]]) -> str:
+    models = {r.get("embedding_model") for r in rows if r.get("embedding_model")}
+    if len(models) == 1:
+        only = next(iter(models))
+        prefix = "sentence-transformers:"
+        return only[len(prefix) :] if only.startswith(prefix) else only
+    return DEFAULT_EMBEDDING_MODEL
+
+
+def write_backup(rows: list[dict[str, Any]], backup_dir: Path, dataset: str) -> Path:
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    out = backup_dir / f"{dataset}_oversized_{ts}.json"
+    payload = []
+    for r in rows:
+        payload.append(
+            {
+                "id": r["id"],
+                "source_id": r["source_id"],
+                "chunk_id": r["chunk_id"],
+                "chunk_index": r["chunk_index"],
+                "content": r["content"],
+                "content_hash": r["content_hash"],
+                "token_count": r["token_count"],
+                "metadata": r["metadata"],
+                "embedding_model": r["embedding_model"],
+                "embedding_dim": r["embedding_dim"],
+                "source_slug": r["source_slug"],
+                "source_title": r["source_title"],
+                "source_url": r["source_url"],
+                "source_type": r["source_type"],
+            }
+        )
+    out.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    return out
+
+
+def apply_one_source(
+    conn: psycopg.Connection,
+    chunks_table: str,
+    rows_for_source: list[dict[str, Any]],
+    sub_chunks_per_row: list[list[dict[str, Any]]],
+    base_index_for_source: int,
+    embedder: EmbedderLazy,
+    embedding_model_name: str,
+) -> tuple[int, int]:
+    """한 source의 거대 chunk들을 트랜잭션 안에서 교체. 반환: (삭제수, 삽입수)."""
+
+    source_id = rows_for_source[0]["source_id"]
+    source_slug = rows_for_source[0]["source_slug"]
+
+    all_subs = [
+        (parent_row, sub)
+        for parent_row, subs in zip(rows_for_source, sub_chunks_per_row)
+        for sub in subs
+    ]
+    if not all_subs:
+        return (0, 0)
+
+    texts_to_embed = [sub["text"] for _, sub in all_subs]
+    vectors = embedder.encode(texts_to_embed)
+    if any(len(v) != EXPECTED_EMBEDDING_DIM for v in vectors):
+        raise RuntimeError(
+            f"embedding dim mismatch for source {source_id}: expected {EXPECTED_EMBEDDING_DIM}"
+        )
+
+    now = datetime.now(timezone.utc)
+    new_rows: list[dict[str, Any]] = []
+    for offset, ((parent_row, sub), vec) in enumerate(zip(all_subs, vectors), start=1):
+        new_index = base_index_for_source + offset
+        new_id = stable_id(source_slug, new_index)
+        text = sub["text"]
+
+        new_rows.append(
+            {
+                "id": new_id,
+                "source_id": source_id,
+                "chunk_id": int(sub.get("chunk_id", offset)),
+                "chunk_index": new_index,
+                "content": text,
+                "content_hash": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+                "token_count": len(text.split()),
+                "metadata": Jsonb(parent_row["metadata"] or {}),
+                "embedding": vector_literal(vec),
+                "embedding_model": f"sentence-transformers:{embedding_model_name}",
+                "embedding_dim": EXPECTED_EMBEDDING_DIM,
+                "embedded_at": now,
+            }
+        )
+
+    delete_sql = sql.SQL("DELETE FROM {chunks} WHERE id = ANY(%s)").format(
+        chunks=sql.Identifier("public", chunks_table)
+    )
+    insert_sql = sql.SQL(
+        """
+        INSERT INTO {chunks} (
+            id, source_id, chunk_id, chunk_index, content, content_hash,
+            token_count, metadata, embedding, embedding_model, embedding_dim, embedded_at
+        ) VALUES (
+            %(id)s, %(source_id)s, %(chunk_id)s, %(chunk_index)s, %(content)s, %(content_hash)s,
+            %(token_count)s, %(metadata)s, %(embedding)s::extensions.vector(384),
+            %(embedding_model)s, %(embedding_dim)s, %(embedded_at)s
+        )
+        """
+    ).format(chunks=sql.Identifier("public", chunks_table))
+
+    parent_ids = [r["id"] for r in rows_for_source]
+    with conn.transaction():
+        with conn.cursor() as cur:
+            cur.execute(delete_sql, (parent_ids,))
+            deleted = cur.rowcount
+            cur.executemany(insert_sql, new_rows)
+    return (deleted, len(new_rows))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dataset", required=True, choices=sorted(DATASET_TABLES))
+    parser.add_argument("--threshold", type=int, default=DEFAULT_THRESHOLD)
+    parser.add_argument("--chunk-size", type=int, default=DEFAULT_CHUNK_SIZE)
+    parser.add_argument("--overlap", type=int, default=DEFAULT_CHUNK_OVERLAP)
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="실제 DELETE/INSERT 실행. 미지정 시 dry-run.",
+    )
+    parser.add_argument("--backup-dir", type=Path, default=DEFAULT_BACKUP_DIR)
+    parser.add_argument(
+        "--no-backup",
+        action="store_true",
+        help="--apply 시 백업을 생략 (권장하지 않음).",
+    )
+    args = parser.parse_args()
+
+    configure_logging()
+    tables = DATASET_TABLES[args.dataset]
+    sources_table = tables["sources"]
+    chunks_table = tables["chunks"]
+    mode = "APPLY (destructive)" if args.apply else "DRY-RUN (no DB changes)"
+
+    log.info("=" * 72)
+    log.info("split_oversized_chunks  dataset=%s  mode=%s", args.dataset, mode)
+    log.info(
+        "threshold=%d  chunk_size=%d  overlap=%d",
+        args.threshold,
+        args.chunk_size,
+        args.overlap,
+    )
+    log.info("tables: public.%s, public.%s", sources_table, chunks_table)
+    log.info("=" * 72)
+
+    conn = connect()
+    try:
+        rows = fetch_oversized(conn, chunks_table, sources_table, args.threshold)
+        log.info("Oversized chunks found: %d", len(rows))
+        if not rows:
+            log.info("Nothing to do.")
+            return 0
+
+        plans: list[tuple[dict[str, Any], list[dict[str, Any]]]] = []
+        for r in rows:
+            subs = split_one(r, args.chunk_size, args.overlap)
+            plans.append((r, subs))
+
+        per_source: dict[str, list[tuple[dict[str, Any], list[dict[str, Any]]]]] = {}
+        for r, subs in plans:
+            per_source.setdefault(r["source_id"], []).append((r, subs))
+
+        log.info("")
+        log.info("--- Plan (per oversized chunk) ---")
+        total_delete = 0
+        total_insert = 0
+        for r, subs in plans:
+            sizes = [len(s["text"]) for s in subs]
+            size_summary = (
+                f"n={len(sizes)} min={min(sizes)} max={max(sizes)} avg={sum(sizes)//len(sizes)}"
+                if sizes
+                else "n=0"
+            )
+            log.info(
+                "  src=%s type=%s  chunk_id=%s idx=%s  cur_len=%d  →  subs: %s",
+                r["source_id"][:12],
+                r["source_type"],
+                r["chunk_id"],
+                r["chunk_index"],
+                len(r["content"]),
+                size_summary,
+            )
+            log.info(
+                "    title=%s",
+                (r["source_title"] or "")[:90],
+            )
+            total_delete += 1
+            total_insert += len(subs)
+
+        log.info("")
+        log.info("--- Summary ---")
+        log.info("affected sources: %d", len(per_source))
+        log.info("chunks to DELETE: %d", total_delete)
+        log.info("chunks to INSERT: %d", total_insert)
+
+        if not args.apply:
+            log.info("")
+            log.info("Dry-run only. Re-run with --apply to execute.")
+            return 0
+
+        if not args.no_backup:
+            backup_path = write_backup(rows, args.backup_dir, args.dataset)
+            log.info("Backup written → %s", backup_path)
+        else:
+            log.warning("Backup skipped by --no-backup flag.")
+
+        base_indexes = max_chunk_index_per_source(conn, chunks_table, list(per_source))
+        embedding_model_name = derive_embedding_model(rows)
+        embedder = EmbedderLazy(embedding_model_name)
+
+        log.info("")
+        log.info("--- Applying changes ---")
+        deleted_total = 0
+        inserted_total = 0
+        for source_id, items in per_source.items():
+            rows_for_source = [r for r, _ in items]
+            subs_for_source = [s for _, s in items]
+            base_idx = base_indexes.get(source_id, -1)
+            deleted, inserted = apply_one_source(
+                conn,
+                chunks_table,
+                rows_for_source,
+                subs_for_source,
+                base_idx,
+                embedder,
+                embedding_model_name,
+            )
+            deleted_total += deleted
+            inserted_total += inserted
+            log.info(
+                "  source=%s  deleted=%d inserted=%d  (new indexes start at %d)",
+                source_id[:12],
+                deleted,
+                inserted,
+                base_idx + 1,
+            )
+
+        log.info("")
+        log.info("Done. deleted=%d  inserted=%d", deleted_total, inserted_total)
+        return 0
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 개요
부경대 공지(pknu_notice/student_life) 데이터 검증 중 발견한 문제 수정 +
질문 검색 품질 개선을 위한 query transform 모듈 1차 작성.

크게 두 갈래 작업이 포함됨 (리뷰 시 구분 부탁):

---
## 1. 거대 chunk 분할

**문제:** 청킹이 문단 단위로만 동작해서, 단일 문단이 chunk_size(900)를
넘어도 분할 안 됨 → 20K~250K자짜리 거대 chunk 생성 (notice 111개,
student_life 5개). 검색 품질 저하.

**수정:**
- `preprocessing.py`: chunk_blocks에 oversized block 사전 분할 로직 추가.
  900자 이하 문단은 기존과 동일(출력 변화 없음), 초과분만 문장 경계 우선 분할.
- `split_oversized_chunks.py`: DB에 이미 적재된 거대 chunk를 외과적으로
  교체하는 1회용 스크립트. **기본 dry-run, --apply 시에만 실제 변경**.
  자동 백업 + source 단위 트랜잭션(rollback) + chunk_index 충돌 방지.

**⚠️ DB 실제 변경(--apply)은 아직 실행 안 함.** dry-run 확인만 완료.
검색 대상 데이터가 바뀌는 작업이라 팀 합의 후 실행 예정.

---
## 2. 질문 검색 정규화 모듈

**목적:** 사용자 자연어 질문을 검색 친화 형태로 가공
(filler 제거 / 약어 정규화 / 좁은 동의어 보강).

- `query_transform.py` 신규. 외부 의존성 없음, self-test 13개 포함.
- baseline 10개 질문 측정 → 사전 설계 원칙 수립
  (광범위 토큰 추가 금지 — false confidence 유발).
- 재측정 결과: 회귀 0, Q2 회귀 해소, Q3·Q7 검색 개선.

**⚠️ backend(ask.py) 통합은 아직 안 함.** 