### PR TITLE
[FEAT] /ask에 pknu 데이터셋 연결 + 질문 정규화 통합 (fan-out)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -17,7 +17,11 @@ EXPECTED_DIMENSIONS=384
 # --- Retrieval ---
 RAG_TOP_K=5
 RAG_MIN_SIMILARITY=0.35
-RPC_NAME=match_rag_documents
+# Comma-separated list of Supabase RPC functions to fan out across.
+# Each RPC must accept (query_embedding, match_count, min_similarity, metadata_filter)
+# and return rows with a `similarity` field. Results are merged client-side
+# and sorted by similarity desc, then trimmed to RAG_TOP_K.
+RPC_NAMES=match_rag_documents,match_pknu_notice_documents,match_pknu_student_life_documents
 MAX_CHARS_PER_CHUNK=500
 
 # --- Server ---

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -35,7 +35,11 @@ class Settings(BaseSettings):
     # Retrieval
     rag_top_k: int = 5
     rag_min_similarity: float = 0.35
-    rpc_name: str = "match_rag_documents"
+    rpc_names: Annotated[List[str], NoDecode] = [
+        "match_rag_documents",
+        "match_pknu_notice_documents",
+        "match_pknu_student_life_documents",
+    ]
     max_chars_per_chunk: int = 500
 
     # Server
@@ -47,22 +51,23 @@ class Settings(BaseSettings):
     log_level: str = "INFO"
     port: int = 8000
 
-    @field_validator("cors_origins", mode="before")
+    @field_validator("cors_origins", "rpc_names", mode="before")
     @classmethod
-    def _split_csv(cls, value):
+    def _split_csv(cls, value, info):
         if isinstance(value, str):
             stripped = value.strip()
             if not stripped:
                 return []
+            field_label = info.field_name.upper()
             if stripped.startswith("["):
                 try:
                     parsed = json.loads(stripped)
                 except json.JSONDecodeError as exc:
                     raise ValueError(
-                        f"CORS_ORIGINS looks like JSON but failed to parse: {exc}"
+                        f"{field_label} looks like JSON but failed to parse: {exc}"
                     ) from exc
                 if not isinstance(parsed, list):
-                    raise ValueError("CORS_ORIGINS JSON must be an array of strings")
+                    raise ValueError(f"{field_label} JSON must be an array of strings")
                 return [str(item).strip() for item in parsed if str(item).strip()]
             return [item.strip() for item in stripped.split(",") if item.strip()]
         return value

--- a/backend/app/retrieval.py
+++ b/backend/app/retrieval.py
@@ -27,21 +27,43 @@ def _vector_literal(vec: List[float]) -> str:
 def search(
     client: Client,
     *,
-    rpc_name: str,
+    rpc_names: List[str],
     embedding: List[float],
     top_k: int,
     min_similarity: float,
     metadata_filter: Optional[Dict[str, Any]] = None,
 ) -> List[Dict[str, Any]]:
-    """Call the `match_rag_documents` (or compatible) RPC and return rows."""
+    """Fan out across RPCs, merge rows, sort by similarity desc, trim to top_k.
 
+    Each RPC must accept the same (query_embedding, match_count, min_similarity,
+    metadata_filter) signature and return rows with a `similarity` field. RPCs
+    apply min_similarity in-DB, so the merged set is already filtered. A failure
+    in one RPC is logged at WARN and skipped — partial results still flow.
+    """
     payload = {
         "query_embedding": _vector_literal(embedding),
         "match_count": top_k,
         "min_similarity": min_similarity,
         "metadata_filter": metadata_filter or {},
     }
-    response = client.rpc(rpc_name, payload).execute()
-    rows = response.data or []
-    logger.info("retrieval: rpc=%s rows=%d", rpc_name, len(rows))
-    return rows
+
+    merged: List[Dict[str, Any]] = []
+    for rpc_name in rpc_names:
+        try:
+            response = client.rpc(rpc_name, payload).execute()
+        except Exception:
+            logger.warning("retrieval: rpc=%s failed, skipping", rpc_name, exc_info=True)
+            continue
+        rows = response.data or []
+        logger.info("retrieval: rpc=%s rows=%d", rpc_name, len(rows))
+        merged.extend(rows)
+
+    merged.sort(key=lambda r: float(r.get("similarity") or 0.0), reverse=True)
+    trimmed = merged[:top_k]
+    logger.info(
+        "retrieval: merged=%d trimmed=%d top_sim=%.3f",
+        len(merged),
+        len(trimmed),
+        float(trimmed[0].get("similarity") or 0.0) if trimmed else 0.0,
+    )
+    return trimmed

--- a/backend/app/routers/ask.py
+++ b/backend/app/routers/ask.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException
 
 from ..deps import AppState, get_state
 from ..generation import generate_answer
+from ..query_transform import transform_query
 from ..retrieval import search
 from ..schemas import AskRequest, AskResponse, Source
 
@@ -24,11 +25,13 @@ def _row_to_source(row: Dict[str, Any]) -> Source:
         metadata.get("doc_title")
         or metadata.get("source_file")
         or metadata.get("title")
+        or row.get("title")
         or row.get("source_slug")
         or "(제목 없음)"
     )
     uri = (
         row.get("uri")
+        or row.get("url")
         or metadata.get("doc_url")
         or metadata.get("source_page_url")
         or metadata.get("attachment_url")
@@ -48,10 +51,11 @@ def ask(payload: AskRequest, state: AppState = Depends(get_state)) -> AskRespons
     if not question:
         raise HTTPException(status_code=400, detail="question must not be empty")
 
-    logger.info("ask: question=%s", question)
+    search_query = transform_query(question) or question
+    logger.info("ask: question=%r search=%r", question, search_query)
 
     try:
-        embedding = state.embedder.encode_query(question)
+        embedding = state.embedder.encode_query(search_query)
     except Exception:
         logger.exception("embedding failed")
         raise HTTPException(status_code=500, detail="embedding failed")
@@ -59,7 +63,7 @@ def ask(payload: AskRequest, state: AppState = Depends(get_state)) -> AskRespons
     try:
         rows = search(
             state.supabase,
-            rpc_name=state.settings.rpc_name,
+            rpc_names=state.settings.rpc_names,
             embedding=embedding,
             top_k=state.settings.rag_top_k,
             min_similarity=state.settings.rag_min_similarity,


### PR DESCRIPTION
## 개요
/ask 엔드포인트가 학부 데이터(rag_chunks)만 검색하던 것을, pknu_notice·
pknu_student_life까지 함께 검색하도록 확장. 더불어 질문 정규화 모듈
(query_transform)을 검색 파이프라인에 통합.

## 변경 내용
- **config.py**: rpc_name(단수) → rpc_names(복수). 기본 3개 RPC.
- **retrieval.py**: search()가 여러 RPC를 fan-out 호출 → 결과 머지 →
  유사도 내림차순 정렬 → top_k 컷. 개별 RPC 실패는 WARN 후 스킵.
- **ask.py**: transform_query를 검색 임베딩에만 적용(LLM엔 원본 전달).
  _row_to_source에 pknu RPC용 flat title/url fallback 추가.
- **.env.example**: RPC_NAMES로 갱신.

## 검증
로컬 백엔드 기동 후 실제 질문 3건으로 라이브 확인:
- "수강신청 기간" → 정확한 답변, fan-out·머지·정렬 동작
- "휴학 절차 알려주세요" → filler 제거 확인, student_life 소스 매핑 확인
- "복전 신청 어떻게 하나요" → 약어 확장(복전→복수전공) 확인

## 범위 밖 (별도 진행)
- **priority 가중치**: 현재 유사도만 사용. RPC returns에 priority_score
  추가는 별도 이슈(재은).
- **pknu_notice RPC timeout**: pknu_notice_chunks의 HNSW 인덱스가 실제
  DB에 빌드되지 않아 검색 시 statement timeout 발생. 별도 이슈로 분리.
  본 PR 코드와 무관하며, 인덱스 빌드 시 코드 변경 없이 자동 합류함.

## 리뷰 노트
이 PR은 backend 단일 영역만 수정. DB/RPC는 건드리지 않음.