### PR TITLE
feat(retrieval): rule 데이터셋 fan-out 추가 + top_k 5→10 확대

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -15,13 +15,13 @@ EMBEDDING_DEVICE=cpu
 EXPECTED_DIMENSIONS=384
 
 # --- Retrieval ---
-RAG_TOP_K=5
+RAG_TOP_K=10
 RAG_MIN_SIMILARITY=0.35
 # Comma-separated list of Supabase RPC functions to fan out across.
 # Each RPC must accept (query_embedding, match_count, min_similarity, metadata_filter)
 # and return rows with a `similarity` field. Results are merged client-side
 # and sorted by similarity desc, then trimmed to RAG_TOP_K.
-RPC_NAMES=match_rag_documents,match_pknu_notice_documents,match_pknu_student_life_documents
+RPC_NAMES=match_rag_documents,match_pknu_notice_documents,match_pknu_student_life_documents,match_rule_documents
 MAX_CHARS_PER_CHUNK=500
 
 # --- Server ---

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -33,12 +33,13 @@ class Settings(BaseSettings):
     expected_dimensions: int = 384
 
     # Retrieval
-    rag_top_k: int = 5
+    rag_top_k: int = 10
     rag_min_similarity: float = 0.35
     rpc_names: Annotated[List[str], NoDecode] = [
         "match_rag_documents",
         "match_pknu_notice_documents",
         "match_pknu_student_life_documents",
+        "match_rule_documents",
     ]
     max_chars_per_chunk: int = 500
 


### PR DESCRIPTION
- /ask의 RPC fan-out에 match_rule_documents 추가 (rule_chunks 5,892행, HNSW 인덱스 존재). 학칙·규정 질문이 정답 데이터셋에 도달할 통로 확보.
- rag_top_k 디폴트 5→10. CE 학과 chunk가 top-5를 점유하면서 다른 데이터셋 정답 후보를 컷 밖으로 밀어내는 fan-out 편향을 부분 완화.
- 12개 시연 질문 진단 결과: Q12(졸업유예) 명확 회복, Q6/Q9 부분 보강. Q5(교환학생 모집)는 CE 장학금 chunk 두께로 미해결, Q8(계절학기)은 학칙 chunk가 진입했으나 chunk 내용 한계로 GPT 거절. 라우팅/quota 등 추가 로직은 발표 후 평가.
- 검색단 코드(retrieval.search) 변경 없음 — 모든 RPC 시그니처 동일.